### PR TITLE
Cache fetched CMC API Requests and other improvements

### DIFF
--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -61,18 +61,18 @@ const AgentCard: React.FC<AgentCardProps> = ({
 	useEffect(() => {
 		const convertMarketCap = async () => {
 			try {
-				const result = await convertCryptoToFiat(marketCap, "SRK", "USD");
+				const result = await convertCryptoToFiat(marketCap, "SRK", "USD", certificate);
 				setConvertedMarketCap(result.toFixed(2));
 			} catch (err) {
 				setError("Error converting market cap to USD: " + err);
 				console.log(error);
 			}
 		};
-
+	
 		if (marketCap > 0) {
 			convertMarketCap();
 		}
-	}, [error, marketCap]);
+	}, [certificate, error, marketCap]);
 
 	const copyToClipboard = (text: string) => {
 		if (text) {

--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -116,55 +116,57 @@ const AgentCard: React.FC<AgentCardProps> = ({
 			<div className="p-5 flex flex-col flex-grow">
 				<div>
 					<div className="flex justify-between items-center">
-					<Link href={{
-						pathname: "/agent",
-						query: {
-							certificate,
-						}
-					}}>
-							<h2 className="text-2xl font-bold tracking-tight hover:text-sparkyOrange-600">
+						<div className="flex-1 min-w-0">
+							<Link href={{
+								pathname: "/agent",
+								query: {
+									certificate,
+								}
+							}}>
+							<h2 className="text-2xl font-bold tracking-tight hover:text-sparkyOrange-600 truncate">
 								{title}
 							</h2>
 						</Link>
-						<div className="flex space-x-1">
-							{website && (
-								<button
-									onClick={() => window.open(website, "_blank", "noopener, noreferrer")}
-									className={socialButtonProperties}
-									title="Website"
-								>
-									<IconWorld size={socialIconSize} />
-								</button>
-							)}
-							{telegram && (
-								<button
-									onClick={() => window.open(telegram, "_blank", "noopener, noreferrer")}
-									className={socialButtonProperties}
-									title="Telegram"
-								>
-									<IconBrandTelegram size={socialIconSize} />
-								</button>
-							)}
-							{twitter && (
-								<button
-									onClick={() => window.open(twitter, "_blank", "noopener, noreferrer")}
-									className={socialButtonProperties}
-									title="X"
-								>
-									<IconBrandX size={socialIconSize} />
-								</button>
-							)}
-							{youtube && (
-								<button
-									onClick={() => window.open(youtube, "_blank", "noopener, noreferrer")}
-									className={socialButtonProperties}
-									title="YouTube"
-								>
-									<IconBrandYoutube size={socialIconSize} />
-								</button>
-							)}
-						</div>
 					</div>
+					<div className="flex space-x-1">
+						{website && (
+							<button
+								onClick={() => window.open(website, "_blank", "noopener, noreferrer")}
+								className={socialButtonProperties}
+								title="Website"
+							>
+								<IconWorld size={socialIconSize} />
+							</button>
+						)}
+						{telegram && (
+							<button
+								onClick={() => window.open(telegram, "_blank", "noopener, noreferrer")}
+								className={socialButtonProperties}
+								title="Telegram"
+							>
+								<IconBrandTelegram size={socialIconSize} />
+							</button>
+						)}
+						{twitter && (
+							<button
+								onClick={() => window.open(twitter, "_blank", "noopener, noreferrer")}
+								className={socialButtonProperties}
+								title="X"
+							>
+								<IconBrandX size={socialIconSize} />
+							</button>
+						)}
+						{youtube && (
+							<button
+								onClick={() => window.open(youtube, "_blank", "noopener, noreferrer")}
+								className={socialButtonProperties}
+								title="YouTube"
+							>
+								<IconBrandYoutube size={socialIconSize} />
+							</button>
+						)}
+					</div>
+				</div>
 
 					<h3 className="mb-2 text-xl tracking-tight truncate w-full flex items-center">
 						<span className="pr-2">CA:</span>

--- a/app/components/AgentSearchBar.tsx
+++ b/app/components/AgentSearchBar.tsx
@@ -3,19 +3,24 @@ import React, { useState } from "react";
 interface AgentSearchBarProps {
   onSearch: (query: string) => void;
   placeholder?: string;
-  onClear?: () => void;  // New prop
+  onClear?: () => void;
+  onSearchButtonClick?: () => void;
 }
 
 const AgentSearchBar: React.FC<AgentSearchBarProps> = ({
   onSearch,
   placeholder = "Search...",
-  onClear
+  onClear,
+  onSearchButtonClick
 }) => {
   const [query, setQuery] = useState("");
 
   const handleSearch = () => {
     if (query.trim()) {
       onSearch(query.trim());
+      if (onSearchButtonClick) {
+        onSearchButtonClick();
+      }
     }
   };
 

--- a/app/components/AgentStats.tsx
+++ b/app/components/AgentStats.tsx
@@ -63,34 +63,36 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 	useEffect(() => {
 		const convertMarketCap = async () => {
 			try {
-				const result = await convertCryptoToFiat(marketCap, "SRK", "USD");
+				console.log("Certificate for Market Cap:", certificate); // Add this line
+				const result = await convertCryptoToFiat(marketCap, "SRK", "USD", certificate);
 				setConvertedMarketCap(result.toFixed(2));
 			} catch (err) {
 				setError("Error converting market cap to USD: " + err);
 				console.log(error);
 			}
 		};
-
+	
 		if (marketCap > 0) {
 			convertMarketCap();
 		}
-	}, [error, marketCap]);
-
+	}, [certificate, error, marketCap]);
+	
 	useEffect(() => {
 		const convertTokenPrice = async () => {
 			try {
-				const result = await convertCryptoToFiat(tokenPrice, "SRK", "USD");
+				console.log("Certificate for Token Price:", certificate); // Add this line
+				const result = await convertCryptoToFiat(tokenPrice, "SRK", "USD", certificate);
 				setConvertedTokenPrice(result.toFixed(2));
 			} catch (err) {
 				setError("Error converting token price to USD: " + err);
 				console.log(error);
 			}
 		};
-
+	
 		if (tokenPrice > 0) {
 			convertTokenPrice();
 		}
-	}, [error, tokenPrice]);
+	}, [certificate, error, tokenPrice]);
 
 	/*useEffect(() => {
 		const darkMode = document.documentElement.classList.contains('dark');

--- a/app/components/Agents.tsx
+++ b/app/components/Agents.tsx
@@ -16,11 +16,15 @@ import { useReadContract } from "thirdweb/react";
 import { getContract, toEther } from "thirdweb";
 import { arbitrumSepolia } from "thirdweb/chains";
 import SparkAgentLogo from "./SparkAgentLogo";
+import { IconArrowLeft, IconArrowRight } from "@tabler/icons-react";
 
 const Agents = () => {
     //const [agents, setAgents] = useState<string[]>([]);
     const [index, setIndex] = useState(0);
     const [address, setAddress] = useState<string>("");
+    const [currentPage, setCurrentPage] = useState(1);
+    const agentsPerPage = 6;
+
     interface AgentData {
         creator: string;
         certificate: string;
@@ -64,7 +68,6 @@ const Agents = () => {
 
     useEffect(() => {
         if (data) {
-            //setAgents((prevAgents) => [...prevAgents, data.toString()]);
             setIndex((prevIndex) => prevIndex + 1);
             setAddress(data.toString());
         }
@@ -73,33 +76,36 @@ const Agents = () => {
     useEffect(() => {
         if (agentData !== undefined) {
             console.log("Agent data:", agentData);
-            const parsedData: AgentData = {
-                creator: agentData[0].toString(),
-                certificate: agentData[1].toString(),
-                pair: agentData[2].toString(),
-                agentToken: agentData[3].toString(),
-                token: agentData[4][0].toString(),
-                tokenName: agentData[4][1].toString(),
-                _tokenName: agentData[4][2].toString(),
-                tokenTicker: agentData[4][3].toString(),
-                supply: parseInt(agentData[4][4].toString()),
-                price: parseInt(agentData[4][5].toString()),
-                marketCap: parseInt(toEther(agentData[4][6])), // todo: further convert to USD
-                liquidity: parseInt(agentData[4][7].toString()),
-                volume: parseInt(agentData[4][8].toString()),
-                volume24H: parseInt(agentData[4][9].toString()),
-                prevPrice: parseInt(agentData[4][10].toString()),
-                lastUpdated: new Date(parseInt(agentData[4][11].toString()) * 1000),
-                description: agentData[5].toString(),
-                image: agentData[6].toString(),
-                twitter: agentData[7].toString(),
-                telegram: agentData[8].toString(),
-                youtube: agentData[9].toString(),
-                website: agentData[10].toString(),
-                trading: agentData[11].valueOf(),
-                tradingOnUniSwap: agentData[12]?.valueOf(),
-            };
-            setAgentsData((prevAgentsData) => [...prevAgentsData, parsedData]);
+            const certificate = agentData[1].toString();
+            if (certificate !== "0x0000000000000000000000000000000000000000") {
+                const parsedData: AgentData = {
+                    creator: agentData[0].toString(),
+                    certificate: certificate,
+                    pair: agentData[2].toString(),
+                    agentToken: agentData[3].toString(),
+                    token: agentData[4][0].toString(),
+                    tokenName: agentData[4][1].toString(),
+                    _tokenName: agentData[4][2].toString(),
+                    tokenTicker: agentData[4][3].toString(),
+                    supply: parseInt(agentData[4][4].toString()),
+                    price: parseInt(agentData[4][5].toString()),
+                    marketCap: parseInt(toEther(agentData[4][6])), // todo: further convert to USD
+                    liquidity: parseInt(agentData[4][7].toString()),
+                    volume: parseInt(agentData[4][8].toString()),
+                    volume24H: parseInt(agentData[4][9].toString()),
+                    prevPrice: parseInt(agentData[4][10].toString()),
+                    lastUpdated: new Date(parseInt(agentData[4][11].toString()) * 1000),
+                    description: agentData[5].toString(),
+                    image: agentData[6].toString(),
+                    twitter: agentData[7].toString(),
+                    telegram: agentData[8].toString(),
+                    youtube: agentData[9].toString(),
+                    website: agentData[10].toString(),
+                    trading: agentData[11].valueOf(),
+                    tradingOnUniSwap: agentData[12]?.valueOf(),
+                };
+                setAgentsData((prevAgentsData) => [...prevAgentsData, parsedData]);
+            }
         }
     }, [agentData]);    
 
@@ -179,6 +185,28 @@ const Agents = () => {
         setFilteredAgents(agentsData);
     }, [agentsData]);
 
+    const handlePageChange = (newPage: number) => {
+        setCurrentPage(newPage);
+    };
+
+    const indexOfLastAgent = currentPage * agentsPerPage;
+    const indexOfFirstAgent = indexOfLastAgent - agentsPerPage;
+    const currentAgents = filteredAgents.slice(indexOfFirstAgent, indexOfLastAgent);
+    const totalPages = Math.ceil(filteredAgents.length / agentsPerPage);
+
+    const getPageNumbers = () => {
+        const pageNumbers = [];
+        const maxPagesToShow = 3;
+        const startPage = Math.max(1, currentPage - Math.floor(maxPagesToShow / 2));
+        const endPage = Math.min(totalPages, startPage + maxPagesToShow - 1);
+
+        for (let i = startPage; i <= endPage; i++) {
+            pageNumbers.push(i);
+        }
+
+        return pageNumbers;
+    };
+
     return (
         <section className="items-center justify-center min-h-screen m-6 lg:mx-2 xl:mx-10 2xl:mx-24">
             <div className="grid grid-cols-1 lg:grid-cols-4 gap-4 lg:gap-6 xl:gap-10 2xl:gap-24 w-full">
@@ -193,19 +221,25 @@ const Agents = () => {
                 {/* Second Column */}
                 <div className="lg:col-span-3 w-full">
                     <div className="flex items-center justify-center h-16 mb-6">
-                        <AgentSearchBar onSearch={(query: string) => {
-                            setSearchQuery(query);
-                        }} onClear={() => {
-                            setSearchQuery("");
-                            setFilteredAgents(agentsData); // Reset to original agents list
-                        }} placeholder="Search Agent/Token" />
+                        <AgentSearchBar
+                            onSearch={(query: string) => {
+                                setSearchQuery(query);
+                            }}
+                            onClear={() => {
+                                setSearchQuery("");
+                                setFilteredAgents(agentsData); // Reset to original agents list
+                            }}
+                            onSearchButtonClick={() => {
+                                setCurrentPage(1);
+                            }}
+                            placeholder="Search Agent/Token"
+                        />
                     </div>
 
                     {/* Agent Cards */}
                     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 2xl:grid-cols-3 gap-6 w-full">
-                        {filteredAgents.length > 0 ? (
-                            filteredAgents
-                                .filter(agent => agent.certificate !== "0x0000000000000000000000000000000000000000")
+                        {currentAgents.length > 0 ? (
+                            currentAgents
                                 .map((agent, index) => (
                                     <AgentCard
                                         key={index}
@@ -229,6 +263,33 @@ const Agents = () => {
                                 No agents found
                             </div>
                         )}
+                    </div>
+
+                    {/* Pagination */}
+                    <div className="flex justify-center mt-6">
+                        <button
+                            onClick={() => handlePageChange(Math.max(1, currentPage - 1))}
+                            className={`px-4 py-2 mx-1 rounded-lg transition-all ${currentPage === 1 ? "bg-gray-100 text-gray-300 dark:bg-gray-800 dark:text-gray-600" : "bg-gray-200 text-gray-700 hover:bg-sparkyOrange-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-sparkyOrange-700"} `}
+                            disabled={currentPage === 1}
+                        >
+                            {<IconArrowLeft />}
+                        </button>
+                        {getPageNumbers().map((pageNumber) => (
+                            <button
+                                key={pageNumber}
+                                onClick={() => handlePageChange(pageNumber)}
+                                className={`px-4 py-2 mx-1 rounded-lg transition-all ${currentPage === pageNumber ? 'bg-sparkyOrange-500 text-white dark:bg-sparkyOrange-700' : 'hover:bg-sparkyOrange-200 bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-sparkyOrange-700'}`}
+                            >
+                                {pageNumber}
+                            </button>
+                        ))}
+                        <button
+                            onClick={() => handlePageChange(Math.min(totalPages, currentPage + 1))}
+                            className="px-4 py-2 mx-1 bg-gray-200 text-gray-700 rounded-lg hover:bg-sparkyOrange-200 transition-all dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-sparkyOrange-700"
+                            disabled={currentPage === totalPages}
+                        >
+                            {<IconArrowRight />}
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR introduces the following

## CMC API Requests are now cached to Local Storage
This improvement stores the fetched values from CMC's price-conversion endpoint, along with their associated certificate or token address, in local storage. This ensures that when the same request is made again, the app can retrieve the data instantly from local storage instead of making a new API call, reducing load times and minimizing unnecessary requests, with the goal of minimizing calls.

The demo below demonstrates that when the cards fetch the price values for the first time, they make an API request. Upon refreshing, the values are then retrieved from local storage instead

https://github.com/user-attachments/assets/7d20e0f2-3e0f-4f5f-9b88-69e04e1681fa

Note: If a certain price value has been stored for more than a day, the price value would be re-fetched to ensure updated values.

Resolves #34 

## Pagination has been implemented
A simple pagination has been implemented to only display 6 agents at a time, preventing overflowing of cards. Additionally, this also helps with reducing the frequency of requests made to display the market cap price since it will only fetch when the associated cards are rendered.
![dbI7eRzecu](https://github.com/user-attachments/assets/5a5e86c2-7fda-49d9-97e4-c3f50294e28f)

Resolves #42 

## Long token names are now truncated
The agent names are now truncated to avoid overflowing.
![truncated](https://github.com/user-attachments/assets/bd6be7f6-0784-410f-bba3-479d7b16c174)

Resolves #41 
