### PR TITLE
Display mypinata token image data

### DIFF
--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -18,7 +18,6 @@ useReadContract,
 } from "thirdweb/react";
 import { getContract, toEther } from "thirdweb";
 import { arbitrumSepolia } from "thirdweb/chains";
-import { AGENTS } from "../lib/utils/agents-sample-data";
 import { getSparkingProgress } from "../lib/utils/formatting";
 
 const AgentPage = () => {
@@ -144,16 +143,14 @@ const AgentPage = () => {
 
         {/* Second Column */}
 				<div className="flex flex-col gap-4">
-          {/* 
-                    {agent && (
-                        <SwapCard
-                            contractAddress={agent.certificate}
-                            ticker={agent.tokenTicker}
-                            image={agent.image}
-                        />
-                    )}Swap Card */}
-
-                    <SparkingProgressCard sparkingProgress={agent?.srkHoldings ? getSparkingProgress(agent.srkHoldings) : 0} />
+          {agent && (
+              <SwapCard
+                  contractAddress={agent.certificate}
+                  ticker={agent.tokenTicker}
+                  image={agent.image}
+              />
+          )}
+          <SparkingProgressCard sparkingProgress={agent?.srkHoldings ? getSparkingProgress(agent.srkHoldings) : 0} />
 				</div>
 			</div>
 		</div>

--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -124,7 +124,7 @@ const AgentPage = () => {
             <AgentStats
               title={agent._tokenName}
               ticker={agent.tokenTicker}
-              image={AGENTS[1].image}
+              image={agent.image}
               imageAlt={agent.tokenName}
               certificate={agent.certificate}
               description={agent.description}
@@ -144,13 +144,14 @@ const AgentPage = () => {
 
         {/* Second Column */}
 				<div className="flex flex-col gap-4">
+          {/* 
                     {agent && (
                         <SwapCard
                             contractAddress={agent.certificate}
                             ticker={agent.tokenTicker}
-                            image={AGENTS[1].image}
+                            image={agent.image}
                         />
-                    )}
+                    )}Swap Card */}
 
                     <SparkingProgressCard sparkingProgress={agent?.srkHoldings ? getSparkingProgress(agent.srkHoldings) : 0} />
 				</div>

--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -9,7 +9,8 @@ import {
 	IconCopy,
 	IconWorld,
 	IconCircleCheck,
-	IconBrandYoutube
+	IconBrandYoutube,
+	IconLoader3
 } from "@tabler/icons-react";
 import Link from "next/link";
 import { motion } from "framer-motion";
@@ -57,7 +58,8 @@ const AgentCard: React.FC<AgentCardProps> = ({
 	const [copied, setCopied] = useState(false);
 	const [convertedMarketCap, setConvertedMarketCap] = useState<number | null>(null);
 	const [error, setError] = useState<string | null>(null);
-
+	const [imgSrc, setImgSrc] = useState(`https://aquamarine-used-bear-228.mypinata.cloud/ipfs/${image}`);
+	const [isLoading, setIsLoading] = useState(true);
 	useEffect(() => {
 		const convertMarketCap = async () => {
 			try {
@@ -103,13 +105,26 @@ const AgentCard: React.FC<AgentCardProps> = ({
 					certificate,
 				}
 			}}>
-				<div className="relative w-full h-64 rounded-t-2xl overflow-hidden">
+				<div className="relative w-full h-64 rounded-t-2xl overflow-hidden flex items-center justify-center">
+					{isLoading && (
+                        <motion.div
+                            animate={{ rotate: 360 }}
+                            transition={{ repeat: Infinity, duration: 1, ease: "linear" }}
+                        >
+                            <IconLoader3 />
+                        </motion.div>
+                    )}
 					<Image
-						src={image}
+						src={imgSrc}
 						alt={imageAlt || "Card image"}
 						layout="fill"
 						objectFit="cover"
 						className="object-cover"
+						onLoadingComplete={() => setIsLoading(false)}
+						onError={() => {
+							setImgSrc('https://images.pexels.com/photos/1183992/pexels-photo-1183992.jpeg');
+							setIsLoading(false);
+						}}
 					/>
 				</div>
 			</Link>

--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -107,25 +107,33 @@ const AgentCard: React.FC<AgentCardProps> = ({
 			}}>
 				<div className="relative w-full h-64 rounded-t-2xl overflow-hidden flex items-center justify-center">
 					{isLoading && (
-                        <motion.div
-                            animate={{ rotate: 360 }}
-                            transition={{ repeat: Infinity, duration: 1, ease: "linear" }}
-                        >
-                            <IconLoader3 />
-                        </motion.div>
-                    )}
-					<Image
-						src={imgSrc}
-						alt={imageAlt || "Card image"}
-						layout="fill"
-						objectFit="cover"
-						className="object-cover"
-						onLoadingComplete={() => setIsLoading(false)}
-						onError={() => {
-							setImgSrc('https://images.pexels.com/photos/1183992/pexels-photo-1183992.jpeg');
-							setIsLoading(false);
-						}}
-					/>
+						<motion.div
+							className="flex items-center justify-center absolute inset-0"
+							animate={{ rotate: 360 }}
+							transition={{ repeat: Infinity, duration: 1, ease: "linear" }}
+						>
+							<IconLoader3 size={64} />
+						</motion.div>
+					)}
+					<motion.div
+						initial={{ opacity: 0 }}
+						animate={{ opacity: isLoading ? 0 : 1 }}
+						transition={{ duration: 0.5 }}
+						className="w-full h-full"
+					>
+						<Image
+							src={imgSrc}
+							alt={imageAlt || "Card image"}
+							layout="fill"
+							objectFit="cover"
+							className="object-cover"
+							onLoadingComplete={() => setIsLoading(false)}
+							onError={() => {
+								setImgSrc('https://images.pexels.com/photos/1183992/pexels-photo-1183992.jpeg');
+								setIsLoading(false);
+							}}
+						/>
+					</motion.div>
 				</div>
 			</Link>
 			<div className="p-5 flex flex-col flex-grow">

--- a/app/components/AgentStats.tsx
+++ b/app/components/AgentStats.tsx
@@ -10,6 +10,7 @@ import {
 	IconWorld,
 	IconCircleCheck,
 	IconBrandYoutube,
+	IconLoader3,
 } from "@tabler/icons-react";
 import Link from "next/link";
 import { motion } from "framer-motion";
@@ -59,6 +60,8 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 	const [convertedMarketCap, setConvertedMarketCap] = useState<number | null>(null);
 	const [convertedTokenPrice, setConvertedTokenPrice] = useState<number | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const [imgSrc, setImgSrc] = useState(`https://aquamarine-used-bear-228.mypinata.cloud/ipfs/${image}`);
+	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
 		const convertMarketCap = async () => {
@@ -111,17 +114,27 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 		<motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="group bg-white dark:bg-[#1a1d21] dark:text-white border-2 border-black rounded-2xl shadow-md flex flex-col h-full relative p-5 md:p-6">
 			{/* Section 1 */}
 			<div className="flex flex-row mb-2">
-				<Link href={""}>
-					<div className="relative w-32 h-32 rounded-full overflow-hidden mr-4">
-						<Image
-							src={image}
-							alt={imageAlt || "Card image"}
-							layout="fill"
-							objectFit="cover"
-							className="object-cover"
-						/>
-					</div>
-				</Link>
+				<div className="relative w-32 h-32 rounded-full overflow-hidden mr-4">
+					{isLoading && (
+						<motion.div
+							animate={{ rotate: 360 }}
+							transition={{ repeat: Infinity, duration: 1, ease: "linear" }}
+						>
+							<IconLoader3 />
+						</motion.div>
+					)}
+					<Image
+						src={imgSrc}
+						alt={imageAlt || "Card image"}
+						layout="fill"
+						objectFit="cover"
+						className="object-cover"
+						onError={() => {
+							setImgSrc('https://images.pexels.com/photos/1183992/pexels-photo-1183992.jpeg');
+							setIsLoading(false);
+						}}
+					/>
+				</div>
 				<div className="flex flex-col flex-grow">
 					<div>
 						<div className="flex justify-between items-center mb-4">

--- a/app/components/Agents.tsx
+++ b/app/components/Agents.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useCallback, useEffect, useState } from "react";
 import AgentSearchBar from "./AgentSearchBar";
-import { AGENTS } from "../lib/utils/agents-sample-data";
 import AgentCard from "./AgentCard";
 import AgentFilter from "./AgentFilter";
 import { client } from "../client";
@@ -19,7 +18,6 @@ import SparkAgentLogo from "./SparkAgentLogo";
 import { IconArrowLeft, IconArrowRight } from "@tabler/icons-react";
 
 const Agents = () => {
-    //const [agents, setAgents] = useState<string[]>([]);
     const [index, setIndex] = useState(0);
     const [address, setAddress] = useState<string>("");
     const [currentPage, setCurrentPage] = useState(1);
@@ -242,9 +240,9 @@ const Agents = () => {
                             currentAgents
                                 .map((agent, index) => (
                                     <AgentCard
-                                        key={index}
+                                        key={`${currentPage}-${index}`}
                                         title={agent._tokenName}
-                                        image={AGENTS[1].image}
+                                        image={agent.image}
                                         imageAlt={agent._tokenName}
                                         certificate={agent.certificate}
                                         description={agent.description}

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,18 @@ const nextConfig: NextConfig = {
         port: "",
         pathname: "**",
       },
+      {
+        protocol: "https",
+        hostname: "gateway.pinata.cloud",
+        port: "",
+        pathname: "**",
+      },
+      {
+        protocol: "https",
+        hostname: "aquamarine-used-bear-228.mypinata.cloud",
+        port: "",
+        pathname: "**",
+      },
     ],
   },
 };


### PR DESCRIPTION
This PR makes it such that the actual images uploaded to Pinata are loaded. A fallback image from Pexels is still loaded in case the agent as no image.

Sample for the AgentCard component
![image](https://github.com/user-attachments/assets/e1e89fb9-576b-49d7-a6ed-d5e27ef9aa55)

Sample for the AgentStats component
![image](https://github.com/user-attachments/assets/c3505268-af86-4599-9198-71642de5007b)