### PR TITLE
UI Improvements

### DIFF
--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -115,11 +115,11 @@ const AgentPage = () => {
   return (
     <div className="items-center justify-center min-h-screen m-6 lg:mx-2 xl:mx-10 2xl:mx-24 mt-16 md:mt-28">
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 w-full">
-        <div className="col-span-3">
-          {!agent && (
+        {!agent && (
+          <div className="col-span-3">
             <NotFound />
-          )}
-        </div>
+          </div>
+        )}    
         {/* First Column */}
         <div className="lg:col-span-2 w-full space-x-1.5">
           {agent && (

--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import { formatNumber, getSparkingProgress, getTimeAgo, truncateHash } from "../lib/utils/formatting";
 import {
@@ -62,10 +62,13 @@ const AgentCard: React.FC<AgentCardProps> = ({
 	const [imgSrc, setImgSrc] = useState(`https://yellow-patient-hare-489.mypinata.cloud/ipfs/${image}`);
 	const [isLoading, setIsLoading] = useState(true);
 	const blockiesIcon = blockies.create({ seed: certificate, size: 16, scale: 8 });
+	const prevImageRef = useRef<string | null>(null);
 
-	useEffect(() => {
-		updateImageSrc(image, blockiesIcon, setImgSrc);
-	}, [image, blockiesIcon]);
+    useEffect(() => {
+		if (prevImageRef.current === image) return;
+		prevImageRef.current = image;
+		updateImageSrc(image, blockiesIcon, setImgSrc, setIsLoading);
+	}, [image, blockiesIcon, imgSrc]);
 
 	useEffect(() => {
 		const convertMarketCap = async () => {
@@ -136,10 +139,6 @@ const AgentCard: React.FC<AgentCardProps> = ({
 							className="object-cover"
 							sizes="(max-width: 768px) 100vw, 33vw"
 							onLoad={() => setIsLoading(false)}
-							onError={() => {
-								setImgSrc(blockiesIcon.toDataURL());
-								setIsLoading(false);
-							}}
 						/>
 					</motion.div>
 				</div>

--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -265,15 +265,15 @@ const AgentCard: React.FC<AgentCardProps> = ({
 						<div className="w-full h-3 rounded-full border border-black overflow-hidden">
 							{/* To fix: avoid using CSS inline styles. */}
 							<div
-								className={`h-full rounded-full
+								className={`h-full rounded-full transition-all duration-1000 ease-in-out
 									${
-									(!trading)
-										? "bg-sparkyOrange"
-										: reserveA
-											? (getSparkingProgress(reserveA, totalSupply, gradThreshold) >= 100 || !trading
-												? "bg-sparkyOrange"
-												: "bg-sparkyGreen-200")
-											: 0 
+										(!trading)
+											? "bg-sparkyOrange"
+											: reserveA
+												? (getSparkingProgress(reserveA, totalSupply, gradThreshold) >= 100 || !trading
+													? "bg-sparkyOrange"
+													: "bg-sparkyGreen-200")
+												: 0 
 									}`}
 								style={{
 									width: `${Math.min(

--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -19,7 +19,7 @@ import { client } from "../client";
 import { getContract } from "thirdweb";
 import { useReadContract } from "thirdweb/react";
 import { arbitrumSepolia } from "thirdweb/chains";
-import { convertCryptoToFiat } from "../lib/utils/utils";
+import { convertCryptoToFiat, updateImageSrc } from "../lib/utils/utils";
 
 interface AgentCardProps {
 	title: string;
@@ -59,9 +59,13 @@ const AgentCard: React.FC<AgentCardProps> = ({
 	const [copied, setCopied] = useState(false);
 	const [convertedMarketCap, setConvertedMarketCap] = useState<number | null>(null);
 	const [error, setError] = useState<string | null>(null);
-	const [imgSrc, setImgSrc] = useState(`https://aquamarine-used-bear-228.mypinata.cloud/ipfs/${image}`);
+	const [imgSrc, setImgSrc] = useState(`https://yellow-patient-hare-489.mypinata.cloud/ipfs/${image}`);
 	const [isLoading, setIsLoading] = useState(true);
 	const blockiesIcon = blockies.create({ seed: certificate, size: 16, scale: 8 });
+
+	useEffect(() => {
+		updateImageSrc(image, blockiesIcon, setImgSrc);
+	}, [image, blockiesIcon]);
 
 	useEffect(() => {
 		const convertMarketCap = async () => {
@@ -130,7 +134,8 @@ const AgentCard: React.FC<AgentCardProps> = ({
 							layout="fill"
 							objectFit="cover"
 							className="object-cover"
-							onLoadingComplete={() => setIsLoading(false)}
+							sizes="(max-width: 768px) 100vw, 33vw"
+							onLoad={() => setIsLoading(false)}
 							onError={() => {
 								setImgSrc(blockiesIcon.toDataURL());
 								setIsLoading(false);

--- a/app/components/AgentStats.tsx
+++ b/app/components/AgentStats.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import { formatNumber, getTimeAgo, truncateHash } from "../lib/utils/formatting";
 import {
@@ -65,10 +65,13 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 	const [imgSrc, setImgSrc] = useState(`https://yellow-patient-hare-489.mypinata.cloud/ipfs/${image}`);
 	const [isLoading, setIsLoading] = useState(true);
 	const blockiesIcon = blockies.create({ seed: certificate, size: 16, scale: 8 });
+	const prevImageRef = useRef<string | null>(null);
 
-	useEffect(() => {
-		updateImageSrc(image, blockiesIcon, setImgSrc);
-	}, [image, blockiesIcon]);
+    useEffect(() => {
+		if (prevImageRef.current === image) return;
+		prevImageRef.current = image;
+		updateImageSrc(image, blockiesIcon, setImgSrc, setIsLoading);
+	}, [image, blockiesIcon, imgSrc]);
 
 	useEffect(() => {
 		const convertMarketCap = async () => {
@@ -146,10 +149,6 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 							className="object-cover"
 							sizes="(max-width: 768px) 100vw, 33vw"
 							onLoad={() => setIsLoading(false)}
-							onError={() => {
-								setImgSrc(blockiesIcon.toDataURL());
-								setIsLoading(false);
-							}}
 						/>
 					</motion.div>
 				</div>
@@ -179,10 +178,6 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 								className="object-cover"
 								sizes="(max-width: 768px) 100vw, 33vw"
 								onLoad={() => setIsLoading(false)}
-								onError={() => {
-									setImgSrc(blockiesIcon.toDataURL());
-									setIsLoading(false);
-								}}
 							/>
 						</motion.div>
 					</div>

--- a/app/components/AgentStats.tsx
+++ b/app/components/AgentStats.tsx
@@ -15,7 +15,7 @@ import {
 import Link from "next/link";
 import { motion } from "framer-motion";
 import blockies from "ethereum-blockies";
-import { convertCryptoToFiat } from "../lib/utils/utils";
+import { convertCryptoToFiat, updateImageSrc } from "../lib/utils/utils";
 import { toast } from "sonner";
 
 interface AgentStatsProps {
@@ -62,9 +62,13 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 	const [convertedMarketCap, setConvertedMarketCap] = useState<number | null>(null);
 	const [convertedTokenPrice, setConvertedTokenPrice] = useState<number | null>(null);
 	const [error, setError] = useState<string | null>(null);
-	const [imgSrc, setImgSrc] = useState(`https://aquamarine-used-bear-228.mypinata.cloud/ipfs/${image}`);
+	const [imgSrc, setImgSrc] = useState(`https://yellow-patient-hare-489.mypinata.cloud/ipfs/${image}`);
 	const [isLoading, setIsLoading] = useState(true);
 	const blockiesIcon = blockies.create({ seed: certificate, size: 16, scale: 8 });
+
+	useEffect(() => {
+		updateImageSrc(image, blockiesIcon, setImgSrc);
+	}, [image, blockiesIcon]);
 
 	useEffect(() => {
 		const convertMarketCap = async () => {

--- a/app/components/AgentStats.tsx
+++ b/app/components/AgentStats.tsx
@@ -387,7 +387,7 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 								</span>
 							</div>
 						</div>
-						<p className="font-normal text-sm line-clamp-3 my-2">{description + "Lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum "}</p>
+						<p className="font-normal text-sm my-2">{description}</p>
 					</div>
 					<div className="truncate -mx-5 flex justify-end space-x-2 px-5">
 						<p className="font-normal text-gray-400 text-xs text-right mr-2">

--- a/app/components/AgentStats.tsx
+++ b/app/components/AgentStats.tsx
@@ -118,7 +118,7 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 		<motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="bg-white dark:bg-[#1a1d21] dark:text-white border-2 border-black rounded-2xl shadow-md flex flex-col h-full relative p-5 md:p-6">
 			{/* Section 1 */}
 			<div className="flex flex-row mb-2">
-				<div className="relative w-32 h-32 rounded-full overflow-hidden mr-4">
+				<div className="relative w-32 h-32 flex-shrink-0 rounded-full overflow-hidden mr-4 hidden md:block">
 					{isLoading && (
 						<motion.div
 							className="absolute inset-0 flex items-center justify-center"
@@ -140,6 +140,8 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 							layout="fill"
 							objectFit="cover"
 							className="object-cover"
+							sizes="(max-width: 768px) 100vw, 33vw"
+							onLoad={() => setIsLoading(false)}
 							onError={() => {
 								setImgSrc(blockiesIcon.toDataURL());
 								setIsLoading(false);
@@ -147,7 +149,153 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 						/>
 					</motion.div>
 				</div>
-				<div className="flex flex-col flex-grow">
+
+				<div className="flex flex-col flex-grow md:hidden">
+					<div className="relative w-32 h-32 rounded-full overflow-hidden flex justify-center items-center mx-auto">
+						{isLoading && (
+							<motion.div
+								className="flex items-center justify-center absolute inset-0"
+								animate={{ rotate: 360 }}
+								transition={{ repeat: Infinity, duration: 1, ease: "linear" }}
+							>
+								<IconLoader3 size={64} />
+							</motion.div>
+						)}
+						<motion.div
+							initial={{ opacity: 0 }}
+							animate={{ opacity: isLoading ? 0 : 1 }}
+							transition={{ duration: 0.5 }}
+							className="w-full h-full flex justify-center items-center"
+						>
+							<Image
+								src={imgSrc}
+								alt={imageAlt || "Card image"}
+								layout="fill"
+								objectFit="cover"
+								className="object-cover"
+								sizes="(max-width: 768px) 100vw, 33vw"
+								onLoad={() => setIsLoading(false)}
+								onError={() => {
+									setImgSrc(blockiesIcon.toDataURL());
+									setIsLoading(false);
+								}}
+							/>
+						</motion.div>
+					</div>
+					<div className="p-2 flex flex-col flex-grow md:hidden">
+						<div>
+							<div className="flex flex-col justify-between items-center">
+								<div className="flex-1 min-w-0 mb-2">
+									<Link href={{
+										pathname: "/agent",
+										query: {
+											certificate,
+										}
+									}}>
+										<h2 className="text-2xl font-bold tracking-tight hover:text-sparkyOrange-600 truncate whitespace-pre-line">
+											{title + " (" + ticker + ")"}
+										</h2>
+									</Link>
+								</div>
+								<div className="flex space-x-1 mb-4">
+									{website && (
+										<button
+											onClick={() => window.open(website, "_blank", "noopener, noreferrer")}
+											className={socialButtonProperties}
+											title="Website"
+											type="button"
+										>
+											<IconWorld size={socialIconSize} />
+										</button>
+									)}
+									{telegram && (
+										<button
+											onClick={() => window.open(telegram, "_blank", "noopener, noreferrer")}
+											className={socialButtonProperties}
+											title="Telegram"
+											type="button"
+										>
+											<IconBrandTelegram size={socialIconSize} />
+										</button>
+									)}
+									{twitter && (
+										<button
+											onClick={() => window.open(twitter, "_blank", "noopener, noreferrer")}
+											className={socialButtonProperties}
+											title="X"
+											type="button"
+										>
+											<IconBrandX size={socialIconSize} />
+										</button>
+									)}
+									{youtube && (
+										<button
+											onClick={() => window.open(youtube, "_blank", "noopener, noreferrer")}
+											className={socialButtonProperties}
+											title="YouTube"
+											type="button"
+										>
+											<IconBrandYoutube size={socialIconSize} />
+										</button>
+									)}
+								</div>
+							</div>
+
+							<h3 className="mb-2 text-xl tracking-tight truncate w-full flex items-center">
+								<span className="pr-2">CA:</span>
+								<button
+									className="flex items-center space-x-2 truncate px-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-sparkyOrange-200 transition-all"
+									onClick={() => { copyToClipboard(certificate); }}
+									type="button"
+								>
+									<span>{`${truncateHash(certificate, 12, 6, 6)}`}</span>
+									{copied ? (
+										<IconCircleCheck size={16} />
+									) : (
+										<IconCopy size={16} />
+									)}
+								</button>
+							</h3>
+						</div>
+
+						<div className="truncate mt-auto -mx-5">
+							<p className="px-5 mb-2 font-normal flex justify-between">
+								<span>{"Created by:"}</span>
+								<Link
+									href={`https://sepolia.arbiscan.io/address/${createdBy}`}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<span className="hover:text-sparkyOrange-600">{truncateHash(createdBy)}</span>
+								</Link>
+							</p>
+							<p className="px-5 mb-2 font-normal flex justify-between">
+								<span>{"Market Cap:"}</span>
+								<span className="font-bold">
+									{convertedMarketCap ? `$${formatNumber(convertedMarketCap)}` : "Fetching..."}
+								</span>
+							</p>
+							<p className="px-5 mb-2 font-normal flex justify-between">
+								<span>{"Price USD:"}</span>
+								<span className="font-bold">
+									{convertedTokenPrice ? `$${formatNumber(convertedTokenPrice)}` : "Fetching..."}
+								</span>
+							</p>
+							<p className="px-5 mb-2 font-normal flex justify-between">
+								<span>{"Price:"}</span>
+								<span className="font-bold">
+									{formatNumber(tokenPrice) + " SRK"}
+								</span>
+							</p>
+							<p className="px-5 font-normal whitespace-pre-line">{description}</p>
+							<p className="font-normal text-gray-400 text-xs px-5 text-right">
+								{`${getTimeAgo(datePublished)}`}
+							</p>
+						</div>
+					</div>
+				</div>
+				
+				<div className="flex flex-col flex-grow hidden md:flex">
 					<div>
 						<div className="flex justify-between items-center mb-4">
 							<Link href={""}>
@@ -235,7 +383,8 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 								</span>
 							</div>
 						</div>
-						<p className="font-normal text-sm line-clamp-3 my-2">{description}</p>					</div>
+						<p className="font-normal text-sm line-clamp-3 my-2">{description + "Lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum dolor wait lorem ipsum "}</p>
+					</div>
 					<div className="truncate -mx-5 flex justify-end space-x-2 px-5">
 						<p className="font-normal text-gray-400 text-xs text-right mr-2">
 							{`Created at`}

--- a/app/components/CreateAgentForm.tsx
+++ b/app/components/CreateAgentForm.tsx
@@ -294,7 +294,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
       </Dialog.Trigger>
       <Dialog.Portal>
       <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-50 z-[100]" />
-        <Dialog.Content className={'fixed bg-white dark:bg-[#1a1d21] dark:text-white left-[50%] top-[50%] z-[101] grid w-[90%] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-black shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-2xl sm:rounded-2xl sm:px-6 sm:py-10 p-4 max-h-[calc(100vh-40px)] overflow-auto'}
+        <Dialog.Content className={'fixed bg-white dark:bg-[#1a1d21] dark:text-white left-[50%] top-[50%] z-[101] grid w-[90%] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-black border-2 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-2xl sm:rounded-2xl sm:px-6 sm:py-10 p-4 max-h-[calc(100vh-40px)] overflow-auto'}
             onInteractOutside={(event) => {
                 event.preventDefault();
             }}>
@@ -304,7 +304,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                     className={buttonVariants({
                         variant: "outline",
                         size: "sm",
-                        className: 'absolute z-[99] top-4 right-4 w-8 active:drop-shadow-none py-3 border border-black transition-all duration-200 cursor-pointer hover:-translate-y-[0.25rem] hover:translate-x-[-0.25rem] hover:text-white hover:shadow-[0.25rem_0.25rem_#000] hover:bg-red-500 active:translate-x-0 active:translate-y-0 active:shadow-none button-2',
+                        className: 'absolute z-[99] top-4 right-4 w-8 active:drop-shadow-none py-3 border border-black dark:bg-white transition-all duration-200 cursor-pointer hover:-translate-y-[0.25rem] hover:translate-x-[-0.25rem] hover:text-white hover:shadow-[0.25rem_0.25rem_#000] dark:hover:bg-red-500 hover:bg-red-500 active:translate-x-0 active:translate-y-0 active:shadow-none button-2',
                     })}
                 >
                     <FontAwesomeIcon icon={faTimes} size='sm' />

--- a/app/components/CreateAgentForm.tsx
+++ b/app/components/CreateAgentForm.tsx
@@ -278,6 +278,8 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
       setCurrentPage(1)
   };
 
+  const textBoxStyling = "bg-gray-200 dark:bg-gray-700 rounded-xl border border-black dark:border-transparent bg-white dark:text-white";
+
   return (
     <Dialog.Root
         open={isOpen}
@@ -291,8 +293,8 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
         {children}
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-50 z-[100]" />
-        <Dialog.Content className={'fixed bg-white left-[50%] top-[50%] z-[101] grid w-[90%] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg sm:rounded-lg sm:px-6 sm:py-10 p-4 max-h-[calc(100vh-40px)] overflow-auto'}
+      <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-50 z-[100]" />
+        <Dialog.Content className={'fixed bg-white dark:bg-[#1a1d21] dark:text-white left-[50%] top-[50%] z-[101] grid w-[90%] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-black shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-2xl sm:rounded-2xl sm:px-6 sm:py-10 p-4 max-h-[calc(100vh-40px)] overflow-auto'}
             onInteractOutside={(event) => {
                 event.preventDefault();
             }}>
@@ -375,7 +377,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="name"
                                       value={name}
@@ -402,7 +404,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <textarea
-                                      className="w-full h-[5.7rem] rounded-xl border-black border mb-0 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-[5.7rem] mb-0 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       name="description"
                                       value={description}
                                       onChange={(e) => setDescription(e.target.value)} // Handle email change
@@ -428,7 +430,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="ticker"
                                       value={ticker}
@@ -457,7 +459,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                                   <button
                                       type="button"
                                       onClick={() => document.getElementById("iconInput")?.click()}
-                                      className="text-start px-5 py-3 rounded-xl border border-black text-[0.9em] transition w-full"
+                                      className={`text-start px-5 py-3 text-[0.9em] transition w-full ${textBoxStyling}`}
                                   >
                                       Select Image
                                   </button>
@@ -514,7 +516,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="number"
                                       name="purchase_amount"
                                       value={purchaseAmount}
@@ -540,7 +542,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="website_link"
                                       value={websiteLink}
@@ -566,7 +568,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="x_link"
                                       value={xLink}
@@ -593,7 +595,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="telegram_link"
                                       value={telegramLink}
@@ -620,7 +622,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="youtube_link"
                                       value={youtubeLink}
@@ -669,7 +671,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="personality"
                                       value={personality}
@@ -696,7 +698,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="first_message"
                                       value={firstMessage}
@@ -723,7 +725,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="lore"
                                       value={lore}
@@ -750,7 +752,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="style"
                                       value={style}
@@ -777,7 +779,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="adjective"
                                       value={adjective}
@@ -804,7 +806,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
                               </div>
                               <Form.Control asChild>
                                   <input
-                                      className="w-full h-12 rounded-xl border-black border mb-1 px-5 py-3 text-[0.9em]"
+                                      className={`w-full h-12 mb-1 px-5 py-3 text-[0.9em] ${textBoxStyling}`}
                                       type="text"
                                       name="knowledge"
                                       value={knowledge}

--- a/app/components/WalletConfirmationStatus.tsx
+++ b/app/components/WalletConfirmationStatus.tsx
@@ -20,7 +20,7 @@ const WalletConfirmationStatus: React.FC<WalletConfirmationStatusProps> = ({ wal
             open={walletConfirmationStatus > 0}>
             <Dialog.Portal>
                 <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-50 z-[100]" />
-                <Dialog.Content className={'fixed bg-white left-[50%] top-[50%] z-[101] grid w-[90%] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg sm:rounded-lg sm:px-6 sm:py-10 p-4 max-h-[calc(100vh-40px)] overflow-auto'}
+                <Dialog.Content className={'fixed bg-white dark:bg-[#1a1d21] dark:text-white left-[50%] top-[50%] z-[101] grid w-[90%] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-black border-2 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-2xl sm:rounded-2xl sm:px-6 sm:py-10 p-4 max-h-[calc(100vh-40px)] overflow-auto'}
                     onInteractOutside={(event) => {
                         event.preventDefault();
                     }}>

--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -75,9 +75,11 @@ export const checkImage = async (url: string) => {
     }
 };
 
-export const updateImageSrc = async (image: string, blockiesIcon: HTMLCanvasElement, setImgSrc: (src: string) => void) => {
+export const updateImageSrc = async (image: string, blockiesIcon: HTMLCanvasElement, setImgSrc: (src: string) => void, setIsLoading: (loading: boolean) => void) => {
     const option1 = `https://yellow-patient-hare-489.mypinata.cloud/ipfs/${image}`;
     const option2 = `https://aquamarine-used-bear-228.mypinata.cloud/ipfs/${image}`;
+
+    setIsLoading(true);
 
     if (image.startsWith('https')) {
         setImgSrc(blockiesIcon.toDataURL());
@@ -92,4 +94,6 @@ export const updateImageSrc = async (image: string, blockiesIcon: HTMLCanvasElem
         setImgSrc(blockiesIcon.toDataURL());
         console.log("Blockies has been used: " + blockiesIcon.toDataURL());
     }
+
+    setIsLoading(false);
 };

--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -64,3 +64,28 @@ export const convertCryptoToFiat = async (
         }
     }
 };
+
+export const checkImage = async (url: string) => {
+    try {
+        const response = await fetch(url);
+        return response.ok;
+    } catch {
+        return false;
+    }
+};
+
+export const updateImageSrc = async (image: string, blockiesIcon: HTMLCanvasElement, setImgSrc: (src: string) => void) => {
+    const option1 = `https://yellow-patient-hare-489.mypinata.cloud/ipfs/${image}`;
+    const option2 = `https://aquamarine-used-bear-228.mypinata.cloud/ipfs/${image}`;
+    
+    if (await checkImage(option1)) {
+        setImgSrc(option1);
+        console.log("Option 1 has been used: " + option1);
+    } else if (await checkImage(option2)) {
+        setImgSrc(option2);
+        console.log("Option 2 has been used: " + option2);
+    } else {
+        setImgSrc(blockiesIcon.toDataURL());
+        console.log("Blockies has been used: " + blockiesIcon.toDataURL());
+    }
+};

--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -1,4 +1,4 @@
-const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+const oneDayInMilliseconds = 1000;
 
 const getCache = (key: string) => {
     const cached = localStorage.getItem(key);
@@ -25,6 +25,7 @@ export const convertCryptoToFiat = async (
     fiatSymbol: string,
     certificate: string
 ) => {
+    console.log('Converting', cryptoAmount, cryptoSymbol, 'to', fiatSymbol);
     const cacheKey = `${certificate}-${cryptoSymbol}-${fiatSymbol}`;
 
     // Caching here
@@ -77,8 +78,11 @@ export const checkImage = async (url: string) => {
 export const updateImageSrc = async (image: string, blockiesIcon: HTMLCanvasElement, setImgSrc: (src: string) => void) => {
     const option1 = `https://yellow-patient-hare-489.mypinata.cloud/ipfs/${image}`;
     const option2 = `https://aquamarine-used-bear-228.mypinata.cloud/ipfs/${image}`;
-    
-    if (await checkImage(option1)) {
+
+    if (image.startsWith('https')) {
+        setImgSrc(blockiesIcon.toDataURL());
+        console.log("Blockies has been used: " + blockiesIcon.toDataURL());
+    } else if (await checkImage(option1)) {
         setImgSrc(option1);
         console.log("Option 1 has been used: " + option1);
     } else if (await checkImage(option2)) {

--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -83,16 +83,12 @@ export const updateImageSrc = async (image: string, blockiesIcon: HTMLCanvasElem
 
     if (image.startsWith('https')) {
         setImgSrc(blockiesIcon.toDataURL());
-        console.log("Blockies has been used: " + blockiesIcon.toDataURL());
     } else if (await checkImage(option1)) {
         setImgSrc(option1);
-        console.log("Option 1 has been used: " + option1);
     } else if (await checkImage(option2)) {
         setImgSrc(option2);
-        console.log("Option 2 has been used: " + option2);
     } else {
         setImgSrc(blockiesIcon.toDataURL());
-        console.log("Blockies has been used: " + blockiesIcon.toDataURL());
     }
 
     setIsLoading(false);

--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -1,4 +1,4 @@
-const oneDayInMilliseconds = 1000;
+const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
 
 const getCache = (key: string) => {
     const cached = localStorage.getItem(key);

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,12 @@ const nextConfig: NextConfig = {
         port: "",
         pathname: "**",
       },
+      {
+        protocol: "https",
+        hostname: "yellow-patient-hare-489.mypinata.cloud",
+        port: "",
+        pathname: "**",
+      },
     ],
   },
 };


### PR DESCRIPTION
This PR introduces the following changes

## Make AgentStats component mobile responsive
This makes it such that the AgentStats component would be mobile responsive. Fore more context, since the header area of the Agents Stats are quite challenging to dynamically make responsive, a new layout has been created to switch between based on screen size.

https://github.com/user-attachments/assets/18deee20-ab73-4985-ad02-81c8fc07c99d

Resolves #45 

## Add Dark Mode to Custom Modals
This adds dark mode to the `CreateAgentForm` component and `WalletConfirmationStatus` components.

Sample for `CreateAgentForm`
![Create Agent Form](https://github.com/user-attachments/assets/3c0e0882-2d01-4167-8d49-69dad9f89935)

Sample for `WalletConfirmationStatus`
![Buying Your Tokens](https://github.com/user-attachments/assets/8457cec9-5b81-4db3-b301-2101fc169ebc)

Resolves #37 

## Cater to all Pinata Domains for Image Fetching
This makes it such that the following Pinata domains are considered for Agent Image fetching
- `aquamarine-used-bear-228.mypinata.cloud`
- `yellow-patient-hare-489.mypinata.cloud`

With that considered, the agent image component would still default to show their identicons.

### Agent with `aquamarine-used-bear-228.mypinata.cloud` domain
![image](https://github.com/user-attachments/assets/ea1222b6-118f-47a1-9cb9-77155de579d1)

### Agent with `yellow-patient-hare-489.mypinata.cloud` domain
![image](https://github.com/user-attachments/assets/a88b7c17-3f9f-49a4-b902-f8cf78f2ee68)

> Note that the screenshots above show images being unnecessarily fetched multiple times due to `useEffect` running repeatedly in certain cases. (See the first screenshot's image being fetched 9 times). This has now been fixed by [this commit](https://github.com/sparkpointio/sparkagent-launchpad/pull/59/commits/fb8184ce67ba835407aa09ffa2c7c7b04b19bad4).

Resolves #48 

## Other Changes
### Add nice Sparking Progress bar transition to non-sparked agents
![chrome_PG55UMQLLa](https://github.com/user-attachments/assets/0c1e6c9f-6dc9-46e3-9c5d-49fdbce97a7e)

-- END PR --