### PR TITLE
Add Google Analytics for Testnet

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { ThirdwebProvider } from "thirdweb/react";
 import Header from "./components/Header";
 import { Footer } from "./components/Footer";
+import Script from "next/script";
 import LightDarkToggle from "./components/layout/light-dark-toggle";
 import { Toaster } from 'sonner'
 
@@ -58,6 +59,22 @@ export default function RootLayout({
         <meta property="og:image" content="/og-image.png" />
         <meta property="og:type" content="website" />
         {/*<meta property="og:url" content="https://sparkpoint.io" />*/}
+
+        {/* Google Analytics */}
+        <Script
+          id="google-analytics"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'G-CLXPCLDCPD', {
+                'anonymize_ip': true
+              });
+            `,
+          }}
+        />
       </head>
       <ThirdwebProvider>
         <body


### PR DESCRIPTION
This PR implements Google Analytics for testnet to monitor user demographics

Before
![before](https://github.com/user-attachments/assets/646d69ce-eb30-41f5-8b80-823f52538e38)

After
![after](https://github.com/user-attachments/assets/c6f830e0-7a8f-4cc2-a790-4f86885ef191)

This closes #65 