### PR TITLE
Integrate Token Conversion API

### DIFF
--- a/app/api/convert-crypto/fetch-price-conversion/[address]/route.ts
+++ b/app/api/convert-crypto/fetch-price-conversion/[address]/route.ts
@@ -21,7 +21,7 @@ export async function POST(
             return NextResponse.json({ error: 'API key is not set' }, { status: 500 });
         }
 
-        const response = await axios.get(`http://${backendUrl}/${endpoint}/${address}`, {
+        const response = await axios.get(`${backendUrl}/${endpoint}/${address}`, {
             headers: {
                 'x-api-key': apiKey
             }

--- a/app/api/convert-crypto/fetch-price-conversion/[address]/route.ts
+++ b/app/api/convert-crypto/fetch-price-conversion/[address]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+import { ConversionType } from '@/app/lib/utils/utils';
+
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ address: string }> }
+): Promise<NextResponse> {
+    try {
+        const address = (await params).address;
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_API_URL;
+        const apiKey = process.env.NEXT_PUBLIC_FORUM_API;
+        const { conversionType }: { conversionType: ConversionType } = await request.json();
+        const endpoint = conversionType === ConversionType.Price ? 'fetchTokenPriceConversion' : 'fetchTokenMarketCapConversion';
+
+        if (!backendUrl) {
+            return NextResponse.json({ error: 'Backend API URL is not set' }, { status: 500 });
+        }
+
+        if (!apiKey) {
+            return NextResponse.json({ error: 'API key is not set' }, { status: 500 });
+        }
+
+        const response = await axios.get(`http://${backendUrl}/${endpoint}/${address}`, {
+            headers: {
+                'x-api-key': apiKey
+            }
+        });
+
+        return NextResponse.json(response.data, { status: 200 });
+    } catch (error) {
+        console.error('Error fetching token price conversion:', error);
+        return NextResponse.json({ error: 'Failed to fetch conversion' }, { status: 500 });
+    }
+}

--- a/app/api/convert-crypto/update-price-conversion/route.ts
+++ b/app/api/convert-crypto/update-price-conversion/route.ts
@@ -24,7 +24,7 @@ export async function POST(
 
         console.log(`Request Payload:  ${certificate}, ${convertedPrice}, ${conversionType}`);
 
-        const response = await axios.post(`http://${backendUrl}/${endpoint}/`, {
+        const response = await axios.post(`${backendUrl}/${endpoint}/`, {
             address,
             conversion,
         }, {

--- a/app/api/convert-crypto/update-price-conversion/route.ts
+++ b/app/api/convert-crypto/update-price-conversion/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+import { ConversionType } from '@/app/lib/utils/utils';
+
+export async function POST(
+    request: NextRequest,
+): Promise<NextResponse> {
+    try {
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_API_URL;
+        const apiKey = process.env.NEXT_PUBLIC_POST_FORUM_API;
+        const { certificate, convertedPrice, conversionType }: { certificate: string; convertedPrice: number; conversionType: ConversionType } = await request.json();
+        const endpoint = conversionType === ConversionType.Price ? 'updateTokenPriceConversion' : 'updateTokenMarketCapConversion';
+
+        const address = certificate;
+        const conversion = convertedPrice;
+
+        if (!backendUrl) {
+            return NextResponse.json({ error: 'Backend API URL is not set' }, { status: 500 });
+        }
+
+        if (!apiKey) {
+            return NextResponse.json({ error: 'API key is not set' }, { status: 500 });
+        }
+
+        console.log(`Request Payload:  ${certificate}, ${convertedPrice}, ${conversionType}`);
+
+        const response = await axios.post(`http://${backendUrl}/${endpoint}/`, {
+            address,
+            conversion,
+        }, {
+            headers: {
+                'x-api-key': apiKey,
+            }
+        });
+
+        console.log('Backend Response:', response.data);
+
+        return NextResponse.json(response.data, { status: 200 });
+    } catch (error) {
+        console.error('Error updating token price conversion:', error);
+        if (axios.isAxiosError(error) && error.response) {
+            console.error('Backend Response Error:', error.response.data);
+        }
+        return NextResponse.json({ error: 'Failed to update conversion' }, { status: 500 });
+    }
+}

--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -15,7 +15,7 @@ import {
 import Link from "next/link";
 import { motion } from "framer-motion";
 import blockies from "ethereum-blockies";
-import { convertCryptoToFiat, updateImageSrc } from "../lib/utils/utils";
+import { ConversionType, convertCryptoToFiat, updateImageSrc } from "../lib/utils/utils";
 import { socialButtonProperties } from "../lib/utils/style/customStyles";
 
 interface AgentCardProps {
@@ -72,7 +72,7 @@ const AgentCard: React.FC<AgentCardProps> = ({
 	useEffect(() => {
 		const convertMarketCap = async () => {
 			try {
-				const result = await convertCryptoToFiat(marketCap, "SRK", "USD", certificate);
+				const result = await convertCryptoToFiat(marketCap, "SRK", "USD", certificate, ConversionType.MarketCap);
 				setConvertedMarketCap(result.toFixed(2));
 			} catch (err) {
 				setError("Error converting market cap to USD: " + err);

--- a/app/components/AgentStats.tsx
+++ b/app/components/AgentStats.tsx
@@ -16,11 +16,11 @@ import {
 import Link from "next/link";
 import { motion } from "framer-motion";
 import blockies from "ethereum-blockies";
-import { convertCryptoToFiat, updateImageSrc } from "../lib/utils/utils";
+import { convertCryptoToFiat, updateImageSrc, ConversionType } from "../lib/utils/utils";
 import { toast } from "sonner";
 import { cardProperties } from "../lib/utils/style/customStyles";
 import { socialButtonProperties } from "../lib/utils/style/customStyles";
-import { getContract, getContractEvents } from "thirdweb";
+import { getContract, getContractEvents, toEther } from "thirdweb";
 import { arbitrumSepolia } from "thirdweb/chains";
 import { client } from "@/app/client";
 import { Hex } from "viem";
@@ -131,7 +131,8 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 			try {
 				if (agentData) {
 					console.log("Certificate for Market Cap:", certificate); // Add this line
-					const result = await convertCryptoToFiat(Number(agentData.data[4][6]), "SRK", "USD", certificate);
+					console.log("Market Cap:", agentData.data[4][6]); // Add this line
+					const result = await convertCryptoToFiat(parseInt(toEther(BigInt(agentData.data[4][6]))), "SRK", "USD", certificate, ConversionType.MarketCap);
 					setConvertedMarketCap(result.toFixed(2));
 				}
 			} catch (err) {
@@ -150,7 +151,7 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 			try {
 				if (agentData) {
 					console.log("Certificate for Token Price:", certificate); // Add this line
-					const result = await convertCryptoToFiat(Number(agentData.data[4][5]), "SRK", "USD", certificate);
+					const result = await convertCryptoToFiat(Number(agentData.data[4][5]), "SRK", "USD", certificate, ConversionType.Price);
 					setConvertedTokenPrice(result.toFixed(2));
 				}
 			} catch (err) {

--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -1,8 +1,8 @@
 export enum ConversionType {
-    Price, // cached to redis
-    MarketCap, // cached to redis
-    Any, // default, not cached
-} 
+    Price, // Conversion based on price, cached to redis
+    MarketCap, // Conversion based on market cap, cached to redis
+    Any, // Default conversion type, NOT cached
+}
 
 const updatePriceConversion = async (certificate: string, convertedPrice: number, conversionType: ConversionType) => {
     try {

--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -1,7 +1,7 @@
 export enum ConversionType {
     Price, // cached to redis
     MarketCap, // cached to redis
-    Any, // not cached
+    Any, // default, not cached
 } 
 
 const updatePriceConversion = async (certificate: string, convertedPrice: number, conversionType: ConversionType) => {

--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -54,13 +54,11 @@ const fetchPriceConversion = async (
         const fetchedData = await response.json();
 
         if (fetchedData.needsUpdating) {
-            console.log('[PRICE CONVERSION] Converted amount needs updating. Fetching from CMC');
             const conversion = await fetchCryptoConversionFromCoinMarketCap(cryptoAmount, cryptoSymbol, fiatSymbol);
 
             await updatePriceConversion(certificate, conversion, conversionType);
             return conversion;
         } else {
-            console.log('[PRICE CONVERSION] Fetched conversion from DB');
             return fetchedData.data.conversion;
         }
 
@@ -112,7 +110,6 @@ export const convertCryptoToFiat = async (
     conversionType: ConversionType = ConversionType.Any
 ) => {
     console.log('Converting', cryptoAmount, cryptoSymbol, 'to', fiatSymbol);
-    console.log('Conversion type:', conversionType);
     
     if (conversionType != ConversionType.Any) {
         return await fetchPriceConversion(cryptoAmount, cryptoSymbol, fiatSymbol, certificate, conversionType);


### PR DESCRIPTION
This pull request introduces two new API routes for handling crypto price conversions. The routes allow fetching and updating token price conversions using the `sparkagent-api`.

New API routes:

- Added a POST route to fetch token price or market cap conversion based on the `ConversionType` via a GET request to the `sparkagent-api`. 
- Added a POST route to update token price or market cap conversion via a POST request to the `sparkagent-api`. Updated token prices are fetched from the CMC API and posted to the `sparkagent-api`.

Previously, each client/user independently fetched the conversion value from the CMC API and stored a local cache on their machine. This new implementation optimizes the process by first checking the database for an updated conversion value.

- If a value exists, the client retrieves it directly from the database.
- If not or if the value is outdated (if the value is _older than one day_), the client fetches the latest value from the CMC API, displays it, and updates the Redis database for other clients to use.

This approach significantly reduces redundant API requests from the CMC API, as the database now acts as a shared cache, ensuring that only one request updates the conversion value when necessary, rather than every client making separate API calls and caching them individually and locally.

### Calculation for the Old Approach

The total number of API requests in the previous implementation is calculated as:

$$
\text{Total Requests} = (\text{Number of Agents}) \times (\text{Days in Month}) \times (\text{Number of Clients}) \times 2
$$

The factor of **2** accounts for fetching price conversions twice -> once for market cap and once for token price.

#### Example Calculation
Given the following values:
- **Number of Agents** = 1,200  
- **Days in a Month** = 31  
- **Number of Clients** = 100  

_Note that in this case, we are assuming that we have a consistent 100 clients (or users) per day_

The total API requests per month would be:

$$
3,720,000 = 1,200 \times 31 \times 100 \times 2 
$$

### Calculation for the New Approach

In the optimized implementation, the total number of API requests is now independent of the number of clients. Instead, each agent fetches the conversion values only when needed, significantly reducing redundant API requests.

The total API requests per month is calculated as:

$$
\text{Total Requests} = (\text{Number of Agents}) \times (\text{Days in Month}) \times 2
$$

The factor of **2** accounts for fetching price conversions twice -> once for market cap and once for token price.

#### Example Calculation
Given the following values:
- **Number of Agents** = 1,200  
- **Days in a Month** = 31  

The total API requests per month would be:

$$
74,400 = 1,200 \times 31 \times 2
$$

### Conclusion: Old vs. New Approach  

The new approach **eliminates redundant API requests** by using a shared database cache instead of each client fetching independently as stated above.  

#### **Total API Requests Comparison**  

| Approach      | Total Requests Per Month (Example) |
|--------------|----------------------|
| **Old** (Per Client) | **3,720,000** |
| **New** (Shared Cache) | **74,400** |

In this case with 100 clients (or users) per day, we get an **CMC API request reduction of ~98%!**

Resolves #34 