### PR TITLE
Fix setting of agent token or SRK percentage should be the exact 18 decimal or wei

### DIFF
--- a/app/components/SwapCard.tsx
+++ b/app/components/SwapCard.tsx
@@ -398,9 +398,10 @@ const SwapCard: React.FC<SwapCardProps> = ({ contractAddress, ticker, image, tra
                             onClick={() => {
                                 const balance =
                                     swapType === "buy"
-                                        ? Number.parseFloat(getFormattedEther(toEther(BigInt(srkBalance)), 2).replace(/,/g, ""))
-                                        : Number.parseFloat(getFormattedEther(toEther(BigInt(agentBalance)), 2).replace(/,/g, ""))
-                                setAmount((balance * 0.25).toFixed(2).toString())
+                                        ? BigInt(srkBalance)
+                                        : BigInt(agentBalance)
+
+                                setAmount(toEther(balance / BigInt("4")));
                             }}
                             className={`text-gray-800 dark:text-gray-200 hover:text-gray-500 dark:hover:text-gray-300 transition-colors`}
                         >
@@ -410,9 +411,10 @@ const SwapCard: React.FC<SwapCardProps> = ({ contractAddress, ticker, image, tra
                             onClick={() => {
                                 const balance =
                                     swapType === "buy"
-                                        ? Number.parseFloat(getFormattedEther(toEther(BigInt(srkBalance)), 2).replace(/,/g, ""))
-                                        : Number.parseFloat(getFormattedEther(toEther(BigInt(agentBalance)), 2).replace(/,/g, ""))
-                                setAmount((balance * 0.5).toFixed(2).toString())
+                                        ? BigInt(srkBalance)
+                                        : BigInt(agentBalance)
+
+                                setAmount(toEther(balance / BigInt("2")));
                             }}
                             className={`text-gray-800 dark:text-gray-200 hover:text-gray-500 dark:hover:text-gray-300 transition-colors`}
                         >
@@ -422,9 +424,10 @@ const SwapCard: React.FC<SwapCardProps> = ({ contractAddress, ticker, image, tra
                             onClick={() => {
                                 const balance =
                                     swapType === "buy"
-                                        ? Number.parseFloat(getFormattedEther(toEther(BigInt(srkBalance)), 2).replace(/,/g, ""))
-                                        : Number.parseFloat(getFormattedEther(toEther(BigInt(agentBalance)), 2).replace(/,/g, ""))
-                                setAmount(balance.toFixed(2).toString())
+                                        ? BigInt(srkBalance)
+                                        : BigInt(agentBalance)
+
+                                setAmount(toEther(balance));
                             }}
                             className={`text-gray-800 dark:text-gray-200 hover:text-gray-500 dark:hover:text-gray-300 transition-colors`}
                         >

--- a/app/lib/utils/formatting.ts
+++ b/app/lib/utils/formatting.ts
@@ -77,8 +77,11 @@ export function getSparkingProgress(reserveB: bigint, gradThreshold: bigint): nu
 }
 
 export function getFormattedEther(balance: string, maxDecimal: number) {
+  const factor = 10 ** maxDecimal;
+  const flooredBalance = Math.floor(Number(balance) * factor) / factor; // Floor instead of rounding
+
   return new Intl.NumberFormat("en-US", {
     minimumFractionDigits: 0,
     maximumFractionDigits: maxDecimal,
-  }).format(Number(balance));
+  }).format(flooredBalance);
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/ac8387e0-e174-4f69-aac3-c493eb6e85ae

Later update to than the video above.

Fixed yung default rounding off. Changed to rounding down or floor para di mag-expect ang user na meron pala silang token kahit rounded up lang naman yun. Naging 0.14 na lang instead of 0.15 dati.

![Screenshot 2025-02-24 163249](https://github.com/user-attachments/assets/7250f261-babe-438d-a07b-82d537b706bd)

Closes #98 