### PR TITLE
Enhance Sorting and Filtering of Agents

### DIFF
--- a/app/components/AgentFilter.tsx
+++ b/app/components/AgentFilter.tsx
@@ -6,34 +6,19 @@ interface FilterProps {
 
 const AgentFilter = ({ onFilterChange }: FilterProps) => {
     const [activeFilters, setActiveFilters] = useState({
-        volume: null as "high" | "low" | null,
-        marketCap: null as "high" | "low" | null,
         newPairs: false,
         sparked: false,
-        price: null as "high" | "low" | null
     });
 
     const handleFilter = (type: string) => {
         const newFilters = { ...activeFilters };
 
         switch (type) {
-            case 'volume':
-                newFilters.volume = activeFilters.volume === "high" ? "low" :
-                    activeFilters.volume === "low" ? null : "high";
-                break;
-            case 'marketCap':
-                newFilters.marketCap = activeFilters.marketCap === "high" ? "low" :
-                    activeFilters.marketCap === "low" ? null : "high";
-                break;
             case 'newPairs':
                 newFilters.newPairs = !activeFilters.newPairs;
                 break;
             case 'sparked':
                 newFilters.sparked = !activeFilters.sparked;
-                break;
-            case 'price':
-                newFilters.price = activeFilters.price === "high" ? "low" :
-                    activeFilters.price === "low" ? null : "high";
                 break;
         }
 
@@ -56,26 +41,6 @@ const AgentFilter = ({ onFilterChange }: FilterProps) => {
             <h2 className={`${filterProperties} font-bold`}>Filter</h2>
             <hr className={dividerProperties} />
             <button
-                className={getButtonClass(!!activeFilters.volume)}
-                onClick={() => handleFilter('volume')}
-            >
-                <p className={filterProperties}>
-                    24H Volume
-                    {activeFilters.volume && <span>{activeFilters.volume === "high" ? "↑" : "↓"}</span>}
-                </p>
-            </button>
-            <hr className={dividerProperties} />
-            <button
-                className={getButtonClass(!!activeFilters.marketCap)}
-                onClick={() => handleFilter('marketCap')}
-            >
-                <p className={filterProperties}>
-                    Market Cap
-                    {activeFilters.marketCap && <span>{activeFilters.marketCap === "high" ? "↑" : "↓"}</span>}
-                </p>
-            </button>
-            <hr className={dividerProperties} />
-            <button
                 className={getButtonClass(activeFilters.newPairs)}
                 onClick={() => handleFilter('newPairs')}
             >
@@ -92,16 +57,6 @@ const AgentFilter = ({ onFilterChange }: FilterProps) => {
                 <p className={filterProperties}>
                     Sparked
                     {activeFilters.sparked && <span>✓</span>}
-                </p>
-            </button>
-            <hr className={dividerProperties} />
-            <button
-                className={`${getButtonClass(!!activeFilters.price)} rounded-b-2xl`}
-                onClick={() => handleFilter('price')}
-            >
-                <p className={filterProperties}>
-                    Token Price
-                    {activeFilters.price && <span>{activeFilters.price === "high" ? "↑" : "↓"}</span>}
                 </p>
             </button>
         </div>

--- a/app/components/AgentSort.tsx
+++ b/app/components/AgentSort.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { useState } from 'react';
+
+interface SortingProps {
+    onSortingChange: (sortType: string, value: string | boolean | null) => void;
+}
+
+const AgentSort = ({ onSortingChange }: SortingProps) => {
+    const [activeSorting, setActiveSorting] = useState({
+        volume: null as "high" | "low" | null,
+        marketCap: null as "high" | "low" | null,
+        price: null as "high" | "low" | null
+    });
+
+    const handleSorting = (type: string) => {
+        const newSorting = {
+            volume: null as "high" | "low" | null,
+            marketCap: null as "high" | "low" | null,
+            price: null as "high" | "low" | null
+        };
+
+        switch (type) {
+            case 'volume':
+                newSorting.volume = activeSorting.volume === "high" ? "low" :
+                    activeSorting.volume === "low" ? null : "high";
+                break;
+            case 'marketCap':
+                newSorting.marketCap = activeSorting.marketCap === "high" ? "low" :
+                    activeSorting.marketCap === "low" ? null : "high";
+                break;
+            case 'price':
+                newSorting.price = activeSorting.price === "high" ? "low" :
+                    activeSorting.price === "low" ? null : "high";
+                break;
+        }
+
+        setActiveSorting(newSorting);
+        onSortingChange(type, newSorting[type as keyof typeof newSorting]);
+    };
+
+    const dividerProperties = "border-t-2 border-black";
+    const filterProperties = "flex text-lg justify-between mx-4 my-2";
+    const buttonProperties = "w-full hover:bg-sparkyOrange-200 transition-colors";
+
+    const getButtonClass = (isActive: boolean) => `
+    ${buttonProperties}
+    ${isActive ? 'bg-sparkyOrange-100 text-black hover:bg-sparkyOrange-200' :
+            'hover:bg-gray-100 dark:hover:bg-gray-800'}
+`;
+
+    return (
+        <div className="bg-white dark:bg-[#1a1d21] dark:text-white h-min border-2 border-black dark:border-gray-700 rounded-2xl shadow-md">
+            <h2 className={`${filterProperties} font-bold`}>Sort</h2>
+            <hr className={dividerProperties} />
+            <button
+                className={getButtonClass(!!activeSorting.volume)}
+                onClick={() => handleSorting('volume')}
+            >
+                <p className={filterProperties}>
+                    24H Volume
+                    {activeSorting.volume && <span>{activeSorting.volume === "high" ? "↑" : "↓"}</span>}
+                </p>
+            </button>
+            <hr className={dividerProperties} />
+            <button
+                className={getButtonClass(!!activeSorting.marketCap)}
+                onClick={() => handleSorting('marketCap')}
+            >
+                <p className={filterProperties}>
+                    Market Cap
+                    {activeSorting.marketCap && <span>{activeSorting.marketCap === "high" ? "↑" : "↓"}</span>}
+                </p>
+            </button>
+            <hr className={dividerProperties} />
+            <button
+                className={`${getButtonClass(!!activeSorting.price)} rounded-b-2xl`}
+                onClick={() => handleSorting('price')}
+            >
+                <p className={filterProperties}>
+                    Token Price
+                    {activeSorting.price && <span>{activeSorting.price === "high" ? "↑" : "↓"}</span>}
+                </p>
+            </button>
+        </div>
+    );
+};
+
+export default AgentSort;

--- a/app/components/AgentStats.tsx
+++ b/app/components/AgentStats.tsx
@@ -460,7 +460,7 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 					<div className="relative w-32 h-32 rounded-full overflow-hidden flex justify-center items-center mx-auto">
 						{isLoading && (
 							<div className="flex items-center justify-center absolute inset-0">
-								<IconLoader3 size={64} />
+								<IconLoader3 size={64} className="animate-spin"/>
 							</div>
 						)}
 						<motion.div
@@ -598,7 +598,7 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 						<div className="flex justify-between items-center mb-4">
 							<Link href={""}>
 								<h2 className="text-2xl font-bold tracking-tight hover:text-sparkyOrange-600">
-									{`${tokenName} (${ticker})`}
+									{agentData ? `${tokenName} (${ticker})` : "Fetching.."}
 								</h2>
 							</Link>
 							<div className="flex space-x-1 items-center">


### PR DESCRIPTION
This pull request includes changes to the `AgentFilter` component, the addition of a new `AgentSort` component, and updates to the `Agents` component to integrate enhanced sorting and filtering functionality.

## Changes to `AgentFilter` component:
* Removed volume, marketCap, and price filters from the `AgentFilter` component. This includes updates to the state and the `handleFilter` function to reflect these removals. 

![image](https://github.com/user-attachments/assets/03704522-9d85-4065-b3cb-736422bbb671)

## Addition of `AgentSort` component:
* Introduced a new `AgentSort` component to handle sorting by volume, marketCap, and price (basically transferring these sorting options from the `AgentFilter` component to its own component). 

![image](https://github.com/user-attachments/assets/97b1ae06-d63e-4668-b13e-740f7c321fd7)

Resolves #86 

## Enhanced Sorting and Filtering of Agents
* Integrated the new `AgentSort` component into the `Agents` component and added state management for sorting options.
* Refactored the filtering and sorting logic in the `Agents` component to apply both filters and sorting in a unified function, `applyFiltersAndSorting`.
* Updated the `handleFilterChange` and `handleSortingChange` functions to manage the new state structure for filters and sorting.

All in all, this allows it such that users will be able to filter and sort agents at the same time, with both functionalities working together.

This is now what the home page looks like.

![image](https://github.com/user-attachments/assets/5dbde808-3ef1-4d21-b8c5-3b302dfb2549)

### Testing different filtering and sorting combinations
To verify the accuracy of the sorting and filtering functionalities, data has been logged for each sorting and filtering combination to ensure that the expected results are correctly applied and displayed as intended.

#### Sorting filtered New Pairs Agents according to 24H Volume

Configuration:
![image](https://github.com/user-attachments/assets/d2b647f8-bd23-4781-a008-37e8afa3377d)

Results:
![image](https://github.com/user-attachments/assets/e31fa924-a1d0-4628-ab75-43bebe78966a)

#### Sorting filtered New Pairs Agents according to Market Cap

Configuration:
![image](https://github.com/user-attachments/assets/97ba57fc-2bf4-4b73-bb7e-4f0fb4e0aab3)

Results:
![image](https://github.com/user-attachments/assets/6353f2af-0bca-4561-98eb-9edcb4dfbcb8)

#### Sorting filtered New Pairs Agents according to Token Price (set to "down" to see relevant changes)

Configuration:
![image](https://github.com/user-attachments/assets/44f2cf6f-bada-4053-a37b-2cd998ea4b8c)

Results
![image](https://github.com/user-attachments/assets/84f696a6-8c2d-4268-90aa-695ccef88857)

#### Sorting filtered Sparked Agents according to 24H Volume

Configuration:
![image](https://github.com/user-attachments/assets/d75385cf-3f40-4385-abef-6e467ed1bb49)

Results
![image](https://github.com/user-attachments/assets/1952e7ea-62bd-4bde-83c1-36d4fe5160e0)

#### Sorting filtered Sparked Agents according to Market Cap

Configuration:
![image](https://github.com/user-attachments/assets/d178ad24-5a5b-4efa-abcc-b144b3a66b36)

Results:
![image](https://github.com/user-attachments/assets/c26127dd-e807-44f6-b2fe-6fb880f02aaa)

#### Sorting filtered Sparked Agents according to Token Price

Configuration:
![image](https://github.com/user-attachments/assets/995b19cb-6813-41c9-91f5-a495da0d02a6)

Results:
![image](https://github.com/user-attachments/assets/b62a90c6-97c4-4bb7-9095-2575e321cd6a)

#### Sorting BOTH filtered Sparked Agents and New Pairs Agents together according to 24 Hour Volume

Configuration:
![image](https://github.com/user-attachments/assets/c4f14b8a-8ac6-42c9-b1f0-15a7725332da)

Results:
![image](https://github.com/user-attachments/assets/ea826b9f-b336-40dc-b08a-be2455615bee)

#### Sorting BOTH filtered Sparked Agents and New Pairs Agents together according to Market Cap

Configuration:
![image](https://github.com/user-attachments/assets/7bb4f55e-5d34-4c4e-9687-bd0e522e3150)

Results:
![image](https://github.com/user-attachments/assets/3846f45a-d768-4aa3-91ba-9053c88535ab)

#### Sorting BOTH filtered Sparked Agents and New Pairs Agents together according to Token Price

Configuration:
![image](https://github.com/user-attachments/assets/608d3e21-c211-4f56-bca4-beb8a4ecad91)

Results
![image](https://github.com/user-attachments/assets/be6b6760-808e-460b-9b38-0c0725326188)

--

Notes: Individual Filtering and Sorting works as how they were originally intended before this update.

Resolves #87 

## Minor Changes:
* Added a loading animation to the `AgentStats` component using the `animate-spin` class.
* Updated the token name display in `AgentStats` to show "Fetching.." when agent data is not yet loaded.