### PR TITLE
Update sparking progress computation

### DIFF
--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -46,6 +46,7 @@ interface AgentData {
   reserves: [bigint, bigint];
   totalSupply: bigint;
   gradThreshold: bigint;
+  initialLiquidity: bigint;
 }
 
 const AgentPage = () => {
@@ -73,6 +74,12 @@ const AgentPage = () => {
     params: [],
   });
 
+  const { data: initialLiquidity } = useReadContract({
+    contract: unsparkingAIContract,
+    method: "function L() returns (uint256)",
+    params: [],
+  });
+
   useEffect(() => {
     const fetchAgentData = async () => {
       try {
@@ -95,6 +102,12 @@ const AgentPage = () => {
             contract: agentPairContract,
             method: "function getReserves() returns (uint256, uint256)",
             params: [],
+          });
+
+          const initialLiquidity = await readContract({
+              contract: unsparkingAIContract,
+              method: "function L() returns (uint256)",
+              params: [],
           });
 
           const totalSupply = await readContract({
@@ -130,7 +143,8 @@ const AgentPage = () => {
             tradingOnUniSwap: agentData[12]?.valueOf(),
             reserves: [reserves[0], reserves[1]],
             totalSupply,
-            gradThreshold: gradThreshold ?? BigInt(0)
+            gradThreshold: gradThreshold ?? BigInt(0),
+            initialLiquidity: initialLiquidity ?? BigInt(0)
           };
 
           console.log("AGENT CERTIFICATE: " + agentData[1].toString());
@@ -152,7 +166,7 @@ const AgentPage = () => {
     };
 
     fetchAgentData();
-  }, [agentData, gradThreshold]);
+  }, [agentData, gradThreshold, initialLiquidity]);
 
   return (
     <div className="items-center justify-center min-h-screen m-6 lg:mx-2 xl:mx-10 2xl:mx-24 mt-16 md:mt-28">
@@ -207,7 +221,7 @@ const AgentPage = () => {
                 />
 
                 <SparkingProgressCard
-                    sparkingProgress={agent?.reserves[1] ? getSparkingProgress(agent.reserves[1], agent.gradThreshold) : 0}
+                    sparkingProgress={agent?.reserves[1] ? getSparkingProgress(agent.reserves[1], agent.gradThreshold, agent.initialLiquidity) : 0}
                     gradThreshold={agent.gradThreshold}
                     trading={agent.trading}
                     contractAddress={agent.certificate}

--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -34,6 +34,7 @@ interface AgentCardProps {
 	trading: boolean;
 	gradThreshold: bigint;
 	reserveB: bigint;
+	initialLiquidity: bigint;
 }
 
 const socialIconSize = 20;
@@ -54,6 +55,7 @@ const AgentCard: React.FC<AgentCardProps> = ({
 	trading,
 	gradThreshold,
 	reserveB,
+	initialLiquidity,
 }) => {
 	const [copied, setCopied] = useState(false);
 	const [convertedMarketCap, setConvertedMarketCap] = useState<number | null>(null);
@@ -220,7 +222,7 @@ const AgentCard: React.FC<AgentCardProps> = ({
 					</p>
 					<hr className="border-black border-2 group-hover:border-sparkyOrange transition-all duration-200" />
 					<div className="px-5">
-						<p className="font-normal text-[0.8em] mt-3 mb-1">{`Sparking Progress: ${!trading ? 100 : reserveB ? getSparkingProgress(reserveB, gradThreshold) : 0}%`}</p>
+						<p className="font-normal text-[0.8em] mt-3 mb-1">{`Sparking Progress: ${!trading ? 100 : reserveB ? getSparkingProgress(reserveB, gradThreshold, initialLiquidity) : 0}%`}</p>
 						<div className="w-full h-3 rounded-full border border-black overflow-hidden">
 							{/* To fix: avoid using CSS inline styles. */}
 							<div
@@ -229,7 +231,7 @@ const AgentCard: React.FC<AgentCardProps> = ({
 										(!trading)
 											? "bg-sparkyOrange"
 											: reserveB
-												? (getSparkingProgress(reserveB, gradThreshold) >= 100 || !trading
+												? (getSparkingProgress(reserveB, gradThreshold, initialLiquidity) >= 100 || !trading
 													? "bg-sparkyOrange"
 													: "bg-sparkyGreen-200")
 												: 0 
@@ -239,7 +241,7 @@ const AgentCard: React.FC<AgentCardProps> = ({
 										(!trading)
 											? 100
 											: reserveB
-												? getSparkingProgress(reserveB, gradThreshold)
+												? getSparkingProgress(reserveB, gradThreshold, initialLiquidity)
 												: 0,
 										100
 									)}%`,

--- a/app/components/Agents.tsx
+++ b/app/components/Agents.tsx
@@ -47,6 +47,7 @@ const Agents = () => {
         trading: boolean;
         tradingOnUniSwap: boolean;
         gradThreshold: bigint;
+        initialLiquidity: bigint;
         reserveB: bigint;
     }
 
@@ -91,7 +92,7 @@ const Agents = () => {
     const [searchQuery, setSearchQuery] = useState("");
     const [isLoading, setIsLoading] = useState(true);
 
-    const parseAgentData = useCallback((agent: RawAgentData, gradThreshold?: bigint): AgentData => {
+    const parseAgentData = useCallback((agent: RawAgentData, gradThreshold?: bigint, initialLiquidity?: bigint): AgentData => {
         const data = agent.data; // Extract `data` array
         const tokenData = data[4]; // Extract the nested token data
 
@@ -121,6 +122,7 @@ const Agents = () => {
             trading: data[11],
             tradingOnUniSwap: data[12],
             gradThreshold: gradThreshold ?? BigInt(0),
+            initialLiquidity: initialLiquidity ?? BigInt(0),
             reserveB: BigInt(agent.reserves[1]),
         };
     }, []);
@@ -308,6 +310,7 @@ const Agents = () => {
                                                 youtube={agent.youtube}
                                                 trading={agent.trading}
                                                 gradThreshold={agent.gradThreshold}
+                                                initialLiquidity={agent.initialLiquidity}
                                                 reserveB={agent.reserveB}
                                             />
                                         ))

--- a/app/components/WalletConfirmationStatus.tsx
+++ b/app/components/WalletConfirmationStatus.tsx
@@ -24,12 +24,16 @@ const WalletConfirmationStatus: React.FC<WalletConfirmationStatusProps> = ({ wal
                 <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-50 z-[100]" />
                 <Dialog.Content className={'fixed bg-white dark:bg-[#1a1d21] dark:text-white left-[50%] top-[50%] z-[101] grid w-[90%] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border-black border-2 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-2xl sm:rounded-2xl sm:px-6 sm:py-10 p-4 max-h-[calc(100vh-40px)] overflow-auto'}
                     onInteractOutside={(event) => {
-                        event.preventDefault();
+                        if((trading && walletConfirmationStatus < 6) || (!trading && walletConfirmationStatus < 4) || (!trading && walletConfirmationStatus < 6)) {
+                            event.preventDefault();
+                        } else {
+                            setWalletConfirmationStatus(0)
+                        }
                     }}>
 
                     <div className={'max-w-md text-center flex flex-col items-center relative pt-4 pb-4'}>
                         <Dialog.Title className="text-lg font-bold mb-4 text-custom-1">
-                            {((trading && walletConfirmationStatus < 6) || (!trading && walletConfirmationStatus < 4))
+                            {((trading && walletConfirmationStatus < 6) || (!trading && walletConfirmationStatus < 4) || (!trading && walletConfirmationStatus < 6))
                                 ? swapType === "buy"
                                     ? "Buying Your Tokens"
                                     : "Selling Your Tokens"
@@ -92,7 +96,7 @@ const WalletConfirmationStatus: React.FC<WalletConfirmationStatusProps> = ({ wal
                                         : "You have successfully sold your " + ticker + ". Your proceeds will be available soon."
                             }
 
-                            {((trading && walletConfirmationStatus === 6) || (!trading && walletConfirmationStatus === 4)) && (
+                            {(trading && walletConfirmationStatus === 6) || (!trading && walletConfirmationStatus === 4) || (!trading && walletConfirmationStatus === 6) ?
                                 <>
                                     <br />
 
@@ -110,7 +114,8 @@ const WalletConfirmationStatus: React.FC<WalletConfirmationStatusProps> = ({ wal
                                         View Transaction
                                     </Link>
                                 </>
-                            )}
+                                : ''
+                            }
                         </Dialog.Description>
                     </div>
                 </Dialog.Content>

--- a/app/lib/utils/formatting.ts
+++ b/app/lib/utils/formatting.ts
@@ -1,3 +1,5 @@
+import { toEther } from "thirdweb";
+
 export function getTimeAgo(date: Date): string {
   const now = new Date();
   const diffInMilliseconds = now.getTime() - date.getTime();
@@ -70,8 +72,8 @@ export function truncateHash(hash: string, maxLength: number = 10, left?: number
 
 import { Decimal } from "decimal.js";
 
-export function getSparkingProgress(reserveB: bigint, gradThreshold: bigint): number {
-  const sparkingProgress = ((Number(reserveB) - 6000) / Number(gradThreshold)) * 100;
+export function getSparkingProgress(reserveB: bigint, gradThreshold: bigint, initialLiquidity: bigint): number {
+  const sparkingProgress = ((Number(toEther(reserveB)) - Number(toEther(initialLiquidity))) / (Number(toEther(gradThreshold)))) * 100;
 
   return Decimal.min(sparkingProgress, 100).toDecimalPlaces(2, Decimal.ROUND_DOWN).toNumber();
 }

--- a/app/lib/utils/formatting.ts
+++ b/app/lib/utils/formatting.ts
@@ -71,7 +71,7 @@ export function truncateHash(hash: string, maxLength: number = 10, left?: number
 import { Decimal } from "decimal.js";
 
 export function getSparkingProgress(reserveB: bigint, gradThreshold: bigint): number {
-  const sparkingProgress = (Number(reserveB) / Number(gradThreshold)) * 100;
+  const sparkingProgress = ((Number(reserveB) - 6000) / Number(gradThreshold)) * 100;
 
   return Decimal.min(sparkingProgress, 100).toDecimalPlaces(2, Decimal.ROUND_DOWN).toNumber();
 }


### PR DESCRIPTION
Dito sa example. 5000 yung sa pagcreate ng agent. Minus 1. Buy 45000. Then Buy 1.

https://github.com/user-attachments/assets/8d5cb549-8986-496c-ba2b-551fd9241771

Included additional fixes lang sa Wallet Confirmation Status Modal. Previously prevented ang click interactions sa labas ng modal. Ngayon disabled pa rin while waiting sa confirmation sa MetaMask, pero enabled na pag successful transaction na. So no need to click the View Transaction to close the modal.