### PR TITLE
Fix agent form and forum fee issues

### DIFF
--- a/app/components/CommentForm.tsx
+++ b/app/components/CommentForm.tsx
@@ -30,6 +30,11 @@ const srkContract = getContract({
     address: process.env.NEXT_PUBLIC_SRK_TOKEN as string,
 });
 
+const burnAmount = readContract({
+    contract: forumContract,
+    method: "function defaultBurnAmount() returns (uint256)",
+});
+
 export function CommentForm({ isOpen, onClose, forumToken, onCommentSubmitted }: CommentFormProps) {
     const [comment, setComment] = useState("");
     const [validationError, setValidationError] = useState("");
@@ -37,6 +42,15 @@ export function CommentForm({ isOpen, onClose, forumToken, onCommentSubmitted }:
     const [minMessageLength, setMinMessageLength] = useState(0);
     const { mutate: sendTransaction } = useSendTransaction();
     const [isLoading, setIsLoading] = useState(false);
+    const [fetchedBurnAmount, setFetchedBurnAmount] = useState(BigInt(0));
+
+    useEffect(() => {
+        async function fetchBurnAmount() {
+            const burnAmountValue = await burnAmount;
+            setFetchedBurnAmount(burnAmountValue);
+        }
+        fetchBurnAmount();
+    }, []);
 
     const account = useActiveAccount();
 
@@ -72,7 +86,7 @@ export function CommentForm({ isOpen, onClose, forumToken, onCommentSubmitted }:
             method: "function approve(address spender, uint256 value)",
             params: [
                 process.env.NEXT_PUBLIC_FORUM_CONTRACT as string,
-                BigInt("1000000000000000000")
+                fetchedBurnAmount
             ],
         });
 

--- a/app/components/CreateAgentForm.tsx
+++ b/app/components/CreateAgentForm.tsx
@@ -76,13 +76,7 @@ export function CreateAgentForm({ children }: { children: React.ReactNode }) {
 
     const currentFee = fee ?? BigInt(0);
     const purchaseAmountInitial = (currentFee / BigInt("1000000000000000000")).toString();
-    const [purchaseAmount, setPurchaseAmount] = useState(0);
-
-    useEffect(() => {
-        const currentFee = fee ?? BigInt(0);
-        const newPurchaseAmount = (currentFee / BigInt("1000000000000000000")).toString();
-        setPurchaseAmount(newPurchaseAmount);
-    }, [fee]);
+    const [purchaseAmount, setPurchaseAmount] = useState("0");
 
     const [paymentTotal, setPaymentTotal] = useState(0);
     useEffect(() => {


### PR DESCRIPTION
This PR introduces the following fixes

### Fix type error being passed to `setPurchaseAmount` within two useEffects
Fix: The useEffects expects `setPurchaseAmount` to be a string datatype, so the default value the `useState` of `purchaseAmount` should also be of type string just like the value in `purchaseAmountInitial`.
![image](https://github.com/user-attachments/assets/04be5c8e-b120-4581-a5c4-327e792b1945)

### Fix default burn amount not being passed in `approve()` contract call when posting forum comments, and therefore the comment that is being posted does not push through
Fix: Fetches the default burn amount in `defaultBurnAmount()` contract call and pass it to the `approve()` contract call instead of passing a hardcoded value.
![image](https://github.com/user-attachments/assets/c3a11d9c-6ec6-4d75-9674-9ef5609f2cd0)

Demo for posting a comment:

https://github.com/user-attachments/assets/e3ca0b93-2700-4243-bff6-a0115fd5f66c

