### PR TITLE
Re-enable Crypto Conversion Fetching and Improvements

### DIFF
--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -15,7 +15,7 @@ import {
 import Link from "next/link";
 import { motion } from "framer-motion";
 import blockies from "ethereum-blockies";
-import { updateImageSrc } from "../lib/utils/utils";
+import { ConversionType, convertCryptoToFiat, updateImageSrc } from "../lib/utils/utils";
 import { socialButtonProperties } from "../lib/utils/style/customStyles";
 
 interface AgentCardProps {
@@ -73,9 +73,8 @@ const AgentCard: React.FC<AgentCardProps> = ({
 	useEffect(() => {
 		const convertMarketCap = async () => {
 			try {
-				//const result = await convertCryptoToFiat(marketCap, "SRK", "USD", certificate, ConversionType.MarketCap);
-				//setConvertedMarketCap(result.toFixed(2));
-				setConvertedMarketCap(null);
+				const result = await convertCryptoToFiat(marketCap, "SRK", "USD", certificate, ConversionType.MarketCap);
+				setConvertedMarketCap(result.toFixed(2));
 			} catch (err) {
 				console.error("Error converting market cap to USD: " + err);
 			}

--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -59,7 +59,6 @@ const AgentCard: React.FC<AgentCardProps> = ({
 }) => {
 	const [copied, setCopied] = useState(false);
 	const [convertedMarketCap, setConvertedMarketCap] = useState<number | null>(null);
-	const [error, setError] = useState<string | null>(null);
 	const [imgSrc, setImgSrc] = useState(`https://yellow-patient-hare-489.mypinata.cloud/ipfs/${image}`);
 	const [isLoading, setIsLoading] = useState(true);
 	const blockiesIcon = blockies.create({ seed: certificate, size: 16, scale: 8 });
@@ -78,15 +77,14 @@ const AgentCard: React.FC<AgentCardProps> = ({
 				//setConvertedMarketCap(result.toFixed(2));
 				setConvertedMarketCap(null);
 			} catch (err) {
-				setError("Error converting market cap to USD: " + err);
-				console.log(error);
+				console.error("Error converting market cap to USD: " + err);
 			}
 		};
 	
 		if (marketCap > 0) {
 			convertMarketCap();
 		}
-	}, [certificate, error, marketCap]);
+	}, [certificate, marketCap]);
 
 	const copyToClipboard = (text: string) => {
 		if (text) {

--- a/app/components/AgentStats.tsx
+++ b/app/components/AgentStats.tsx
@@ -16,11 +16,11 @@ import {
 import Link from "next/link";
 import { motion } from "framer-motion";
 import blockies from "ethereum-blockies";
-import { updateImageSrc} from "../lib/utils/utils";
+import { ConversionType, convertCryptoToFiat, updateImageSrc} from "../lib/utils/utils";
 import { toast } from "sonner";
 import { cardProperties } from "../lib/utils/style/customStyles";
 import { socialButtonProperties } from "../lib/utils/style/customStyles";
-import { getContract, getContractEvents } from "thirdweb";
+import { getContract, getContractEvents, toEther } from "thirdweb";
 import { arbitrum } from "thirdweb/chains";
 import { client } from "@/app/client";
 import { Hex } from "viem";
@@ -93,7 +93,6 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 	//const [isDarkMode, setIsDarkMode] = useState(false);
 	const [convertedMarketCap, setConvertedMarketCap] = useState<number | null>(null);
 	const [convertedTokenPrice, setConvertedTokenPrice] = useState<number | null>(null);
-	const [error, setError] = useState<string | null>(null);
 	const [imgSrc, setImgSrc] = useState(`https://yellow-patient-hare-489.mypinata.cloud/ipfs/${image}`);
 	const [isLoading, setIsLoading] = useState(true);
 	const blockiesIcon = blockies.create({ seed: certificate, size: 16, scale: 8 });
@@ -112,43 +111,35 @@ const AgentStats: React.FC<AgentStatsProps> = ({
 		const convertMarketCap = async () => {
 			try {
 				if (agentData) {
-					// console.log("Certificate for Market Cap:", certificate);
-					// console.log("Market Cap:", agentData.data[4][6]);
-
-					//const result = await convertCryptoToFiat(parseInt(toEther(BigInt(agentData.data[4][6]))), "SRK", "USD", certificate, ConversionType.MarketCap);
-					//setConvertedMarketCap(result.toFixed(2));
-					setConvertedMarketCap(null);
+					const result = await convertCryptoToFiat(parseInt(toEther(BigInt(agentData.data[4][6]))), "SRK", "USD", certificate, ConversionType.MarketCap);
+					setConvertedMarketCap(result.toFixed(2));
 				}
 			} catch (err) {
-				setError("Error converting market cap to USD: " + err);
-				console.log(error);
+				console.error("Error converting market cap to USD: " + err);
 			}
 		};
 
 		if (agentData && Number(agentData.data[4][6]) > 0) {
 			convertMarketCap();
 		}
-	}, [certificate, error, agentData]);
+	}, [certificate, agentData]);
 
 	useEffect(() => {
 		const convertTokenPrice = async () => {
 			try {
 				if (agentData) {
-					// console.log("Certificate for Token Price:", certificate);
-					//const result = await convertCryptoToFiat(Number(agentData.data[4][5]), "SRK", "USD", certificate, ConversionType.Price);
-					//setConvertedTokenPrice(result.toFixed(2));
-					setConvertedTokenPrice(null);
+					const result = await convertCryptoToFiat(Number(agentData.data[4][5]), "SRK", "USD", certificate, ConversionType.Price);
+					setConvertedTokenPrice(result.toFixed(2));
 				}
 			} catch (err) {
-				setError("Error converting token price to USD: " + err);
-				console.log(error);
+				console.error("Error converting token price to USD: " + err);
 			}
 		};
 
 		if (agentData && Number(agentData.data[4][5]) > 0) {
 			convertTokenPrice();
 		}
-	}, [certificate, error, agentData]);
+	}, [certificate, agentData]);
 
 	/*useEffect(() => {
 		const darkMode = document.documentElement.classList.contains('dark');

--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -4,7 +4,6 @@ export enum ConversionType {
     Any, // Default conversion type, NOT cached
 }
 
-/*
 const updatePriceConversion = async (certificate: string, convertedPrice: number, conversionType: ConversionType) => {
     try {
         const response = await fetch(`/api/convert-crypto/update-price-conversion`, {
@@ -33,9 +32,7 @@ const updatePriceConversion = async (certificate: string, convertedPrice: number
         }
     }
 }
-*/
 
-/*
 const fetchPriceConversion = async (
     cryptoAmount: number,
     cryptoSymbol: string,
@@ -73,9 +70,7 @@ const fetchPriceConversion = async (
         }
     }
 }
-*/
 
-/*
 const fetchCryptoConversionFromCoinMarketCap = async (cryptoAmount: number, cryptoSymbol: string, fiatSymbol: string) => {
     try {
         const response = await fetch('/api/convert-crypto', {
@@ -106,7 +101,6 @@ const fetchCryptoConversionFromCoinMarketCap = async (cryptoAmount: number, cryp
         }
     }
 }
-*/
 
 export const convertCryptoToFiat = async (
     cryptoAmount: number,
@@ -119,7 +113,6 @@ export const convertCryptoToFiat = async (
     console.log('Conversion type:', conversionType);
     console.log('Certificate:', certificate);
     
-    /*
     if (conversionType != ConversionType.Any) {
         return await fetchPriceConversion(cryptoAmount, cryptoSymbol, fiatSymbol, certificate, conversionType);
     } else {
@@ -127,9 +120,6 @@ export const convertCryptoToFiat = async (
         const conversion = await fetchCryptoConversionFromCoinMarketCap(cryptoAmount, cryptoSymbol, fiatSymbol);
         return conversion;
     }
-    */
-
-    return null;
 };
 
 export const checkImage = async (url: string) => {


### PR DESCRIPTION
Previously, if the app fails to fetch or post crypto-conversions from and to the `sparkagent-api`, the app reattempts to fetch these data repeatedly until the data requested has been successfully retrieved or posted.

**Example**
Fetch/Post to `sparkagent-api` ➡️ error? ➡️ repeat to first step ↩️

This fixes that issue and would only attempt to fetch/post once regardless if there is an error or not.