### PR TITLE
Fix Market Cap Misalignment in Agent Sorting

### DIFF
--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -87,6 +87,11 @@ const AgentCard: React.FC<AgentCardProps> = ({
         }
     }, [certificate, marketCap]);
 
+	useEffect(() => {
+        hasFetchedMarketCap.current = false;
+		setConvertedMarketCap(null);
+    }, [certificate, marketCap]);
+
 	const copyToClipboard = (text: string) => {
 		if (text) {
 			navigator.clipboard.writeText(text);

--- a/app/components/AgentCard.tsx
+++ b/app/components/AgentCard.tsx
@@ -87,11 +87,6 @@ const AgentCard: React.FC<AgentCardProps> = ({
         }
     }, [certificate, marketCap]);
 
-	useEffect(() => {
-        hasFetchedMarketCap.current = false;
-		setConvertedMarketCap(null);
-    }, [certificate, marketCap]);
-
 	const copyToClipboard = (text: string) => {
 		if (text) {
 			navigator.clipboard.writeText(text);

--- a/app/components/Agents.tsx
+++ b/app/components/Agents.tsx
@@ -339,7 +339,7 @@ const Agents = () => {
                                     currentAgents
                                         .map((agent, index) => (
                                             <AgentCard
-                                                key={`${currentPage}-${index}`}
+                                                key={`${currentPage}-${index}-${agent.certificate}`}
                                                 title={agent._tokenName}
                                                 image={agent.image}
                                                 imageAlt={agent._tokenName}


### PR DESCRIPTION
This pull request fixes the issue where converted market cap values were not being correctly reassigned to their corresponding agents after sorting. The agents were being sorted properly, but their converted market cap values remained in their original positions.

**Cause:**
- PR #124 introduced optimizations that prevents re-fetching of market cap price conversion data regardless of any state changes. With that, it inadvertently caused the market cap values to remain static, even when agents were sorted. As a result, while the sorting logic correctly rearranged the agents, their market cap values did not update accordingly, leading to a mismatch between agents and their displayed market caps.

**Fixes & Improvements:**
- Ensure uniqueness of key property to the AgentCard component to ensure React properly tracks re-renders.
- Ensured that market cap values are correctly associated with their respective agents after sorting.

These updates resolves inconsistencies in market cap display when selecting different sorting options.

- Made it such that the sorted AgentCard components will reanimate itself for better UX instead of just visually swapping details.

![chrome_8dstfcIfyc](https://github.com/user-attachments/assets/c972e89c-e25b-457e-8fac-b14a7ba6611e)

Resolves #126 